### PR TITLE
Support mouse events on annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,28 @@ To configure the annotations plugin, you can simply add new config options to yo
 			scaleID: 'y-axis-0',
 			value: '25',
 			borderColor: 'red',
-			borderWidth: 2
+			borderWidth: 2,
+
+			// Fires when the user clicks this annotation on the chart
+			// (be sure to enable the event in the events array below).
+			onClick: function(e) {
+				// `this` is bound to the annotation element
+			}
 		}],
+
 		// Defines when the annotations are drawn.
 		// This allows positioning of the annotation relative to the other
 		// elements of the graph.
+		//
 		// Should be one of: afterDraw, afterDatasetsDraw, beforeDatasetsDraw
 		// See http://www.chartjs.org/docs/#advanced-usage-creating-plugins
-		drawTime: "afterDraw" // (default)
+		drawTime: 'afterDraw', // (default)
+
+		// Mouse events to enable on each annotation.
+		// Similar to the `events` common chart configuration option
+		// http://www.chartjs.org/docs/#chart-configuration-common-chart-configuration
+		// Should be an array of: mousemove, mousedown, mouseup, click, dblclick, contextmenu, wheel
+		events: ['click']
 	}
 }
 ```
@@ -36,6 +50,7 @@ Vertical or horizontal lines are supported.
 ```javascript
 {
 	type: 'line',
+
 	// set to 'vertical' to draw a vertical line
 	mode: 'horizontal',
 
@@ -105,7 +120,17 @@ Vertical or horizontal lines are supported.
 
 		// Text to display in label - default is null
 		content: "Test label"
-	}
+	},
+
+	// Mouse event handlers - be sure to enable the corresponding events in the
+	// annotation events array or the event handler will not be called.
+	onMousemove: function(e) {},
+	onMousedown: function(e) {},
+	onMouseup: function(e) {},
+	onClick: function(e) {},
+	onDblclick: function(e) {},
+	onContextmenu: function(e) {},
+	onWheel: function(e) {}
 }
 ```
 
@@ -143,12 +168,24 @@ The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the bo
 	borderWidth: 2,
 
 	// Fill color
-	backgroundColor: 'green'
+	backgroundColor: 'green',
+
+	// Mouse event handlers - be sure to enable the corresponding events in the
+	// annotation events array or the event handler will not be called.
+	onMousemove: function(e) {},
+	onMousedown: function(e) {},
+	onMouseup: function(e) {},
+	onClick: function(e) {},
+	onDblclick: function(e) {},
+	onContextmenu: function(e) {},
+	onWheel: function(e) {}
 }
 ```
 
 ## To-do Items
+
 The following features still need to be done:
+
 * Point Annotations
 * Text annotations
 

--- a/samples/box.html
+++ b/samples/box.html
@@ -128,6 +128,7 @@
                     },
                     annotation: {
                         drawTime: "afterDraw",
+                        events: ['dblclick'],
                         annotations: [{
                             type: 'box',
                             xScaleID: 'x-axis-1',
@@ -138,7 +139,10 @@
                             yMax: 20,
                             backgroundColor: 'rgba(101, 33, 171, 0.5)',
                             borderColor: 'rgb(101, 33, 171)',
-                            borderWidth: 1
+                            borderWidth: 1,
+                            onDblclick: function(e) {
+                                console.log('Box', e.type, this);
+                            }
                         }]
                     }
                 }

--- a/samples/horizontal-line.html
+++ b/samples/horizontal-line.html
@@ -127,14 +127,22 @@
                         }]
                     },
                     annotation: {
+                        events: ['click'],
                         annotations: [{
                             type: 'line',
                             mode: 'horizontal',
                             scaleID: 'y-axis-1',
                             value: 120,
                             borderColor: 'black',
-                            borderWidth: 5
+                            borderWidth: 5,
+                            onClick: function(e) {
+                                // The annotation is is bound to the `this` variable
+                                alert('Annotation ' + e.type);
+                            }
                         }]
+                    },
+                    onClick: function(e, annotation) {
+                        alert('Chart ' + e.type);
                     }
                 }
             });

--- a/samples/labels.html
+++ b/samples/labels.html
@@ -131,6 +131,7 @@
                         }]
                     },
                     annotation: {
+                        events: ['click'],
                         annotations: [{
                             type: 'line',
                             mode: 'horizontal',
@@ -143,6 +144,10 @@
                                 backgroundColor: "red",
                                 content: "This is a long test label",
                                 enabled: true
+                            },
+                            onClick: function(e) {
+                                // The annotation is is bound to the `this` variable
+                                console.log('Annotation', e.type, this);
                             }
                         },
                         {
@@ -158,6 +163,10 @@
                                 yAdjust: 100,
                                 content: "This is a another test label",
                                 enabled: true
+                            },
+                            onClick: function(e) {
+                                // The annotation is is bound to the `this` variable
+                                console.log('Annotation', e.type, this);
                             }
                         }]
                     }

--- a/src/element.js
+++ b/src/element.js
@@ -1,0 +1,19 @@
+module.exports = function(Chart) {
+	var AnnotationElement = Chart.Element.extend({
+		initialize: function() {
+			this.hidden = false;
+			this.setDataLimits();
+		},
+		destroy: function() {},
+		setDataLimits: function() {},
+		configure: function() {},
+		inRange: function() {},
+		getCenterPoint: function() {},
+		getWidth: function() {},
+		getHeight: function() {},
+		getArea: function() {},
+		draw: function() {}
+	});
+
+	return AnnotationElement;
+};

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,3 +1,7 @@
+var Chart = require('chart.js');
+Chart = typeof(Chart) === 'function' ? Chart : window.Chart;
+var chartHelpers = Chart.helpers;
+
 function isValid(num) {
 	return !isNaN(num) && isFinite(num);
 }
@@ -12,7 +16,69 @@ function decorate(obj, prop, func) {
 	}
 }
 
+function getEventHandlerName(eventName) {
+	return 'on' + eventName[0].toUpperCase() + eventName.substring(1);
+}
+
+function getScaleLimits(scaleId, annotations, scaleMin, scaleMax) {
+	var ranges = annotations.filter(function(annotation) {
+		return !!annotation._model.ranges[scaleId];
+	}).map(function(annotation) {
+		return annotation._model.ranges[scaleId];
+	});
+
+	var min = ranges.map(function(range) {
+		return Number(range.min);
+	}).reduce(function(a, b) {
+		return isFinite(b) && !isNaN(b) && b < a ? b : a;
+	}, scaleMin);
+
+	var max = ranges.map(function(range) {
+		return Number(range.max);
+	}).reduce(function(a, b) {
+		return isFinite(b) && !isNaN(b) && b > a ? b : a;
+	}, scaleMax);
+
+	return {
+		min: min,
+		max: max
+	};
+}
+
+function getNearestItems(annotations, position) {
+	var minDistance = Number.POSITIVE_INFINITY;
+
+	return annotations
+		.filter(function(element) {
+			return element.inRange(position.x, position.y);
+		})
+		.reduce(function(nearestItems, element) {
+			var center = element.getCenterPoint();
+			var distance = chartHelpers.distanceBetweenPoints(position, center);
+
+			if (distance < minDistance) {
+				nearestItems = [element];
+				minDistance = distance;
+			} else if (distance === minDistance) {
+				// Can have multiple items at the same distance in which case we sort by size
+				nearestItems.push(element);
+			}
+
+			return nearestItems;
+		}, [])
+		.sort(function(a, b) {
+			// If there are multiple elements equally close,
+			// sort them by size, then by index
+			var sizeA = a.getArea(), sizeB = b.getArea();
+			return (sizeA > sizeB || sizeA < sizeB) ? sizeA - sizeB : a._index - b._index;
+		})
+		.slice(0, 1)[0]; // return only the top item
+}
+
 module.exports = {
 	isValid: isValid,
-	decorate: decorate
+	decorate: decorate,
+	getEventHandlerName: getEventHandlerName,
+	getScaleLimits: getScaleLimits,
+	getNearestItems: getNearestItems
 };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -76,11 +76,13 @@ function build(configs, chartInstance) {
 			var annotation = annotationTypes[config.type];
 			var annotationObject = new annotation({
 				_index: i,
-				config: config
+				options: config,
+				chartInstance: chartInstance,
+				ctx: chartInstance.chart.ctx
 			});
 
 			// Set the data range for this annotation
-			annotationObject.setRanges(config, chartInstance);
+			annotationObject.setRanges();
 
 			return annotationObject;
 		});
@@ -152,7 +154,7 @@ var annotationPlugin = {
 	afterScaleUpdate: function(chartInstance) {
 		if (chartHelpers.isArray(chartInstance.annotations)) {
 			chartInstance.annotations.forEach(function(annotation) {
-				annotation.configure(annotation.config, chartInstance);
+				annotation.configure();
 			});
 		}
 	},

--- a/src/types/box.js
+++ b/src/types/box.js
@@ -3,13 +3,16 @@ var helpers = require('../helpers.js');
 // Box Annotation implementation
 module.exports = function(Chart) {
 	var BoxAnnotation = Chart.Element.extend({
-		setRanges: function(options, chartInstance) {
+		setRanges: function() {
 			var model = this._model = this._model || {};
+			var options = this.options;
+			var chartInstance = this.chartInstance;
 
 			var xScale = chartInstance.scales[options.xScaleID];
 			var yScale = chartInstance.scales[options.yScaleID];
 			var chartArea = chartInstance.chartArea;
 
+			// Set the data range for this annotation
 			model.ranges = {};
 
 			if (xScale) {
@@ -32,8 +35,10 @@ module.exports = function(Chart) {
 				};
 			}
 		},
-		configure: function(options, chartInstance) {
+		configure: function() {
 			var model = this._model = this._model || {};
+			var options = this.options;
+			var chartInstance = this.chartInstance;
 
 			var xScale = chartInstance.scales[options.xScaleID];
 			var yScale = chartInstance.scales[options.yScaleID];
@@ -79,8 +84,9 @@ module.exports = function(Chart) {
 			model.borderWidth = options.borderWidth;
 			model.backgroundColor = options.backgroundColor;
 		},
-		draw: function(ctx) {
+		draw: function() {
 			var view = this._view;
+			var ctx = this.ctx;
 
 			// Canvas setup
 			ctx.save();

--- a/src/types/box.js
+++ b/src/types/box.js
@@ -2,8 +2,8 @@ var helpers = require('../helpers.js');
 
 // Box Annotation implementation
 module.exports = function(Chart) {
-	var BoxAnnotation = Chart.Element.extend({
-		setRanges: function() {
+	var BoxAnnotation = Chart.Annotation.Element.extend({
+		setDataLimits: function() {
 			var model = this._model = this._model || {};
 			var options = this.options;
 			var chartInstance = this.chartInstance;
@@ -83,6 +83,28 @@ module.exports = function(Chart) {
 			model.borderColor = options.borderColor;
 			model.borderWidth = options.borderWidth;
 			model.backgroundColor = options.backgroundColor;
+		},
+		inRange: function(mouseX, mouseY) {
+			return this._view &&
+				mouseX >= this._view.left && 
+				mouseX <= this._view.right && 
+				mouseY >= this._view.top && 
+				mouseY <= this._view.bottom;
+		},
+		getCenterPoint: function() {
+			return {
+				x: (this._view.right + this._view.left) / 2,
+				y: (this._view.bottom + this._view.top) / 2
+			};
+		},
+		getWidth: function() {
+			return Math.abs(this._view.right - this._view.left);
+		},
+		getHeight: function() {
+			return Math.abs(this._view.bottom - this._view.top);
+		},
+		getArea: function() {
+			return this.getWidth() * this.getHeight();
 		},
 		draw: function() {
 			var view = this._view;

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -10,17 +10,21 @@ module.exports = function(Chart) {
 	var verticalKeyword = 'vertical';
 
 	var LineAnnotation = Chart.Element.extend({
-		setRanges: function(options) {
+		setRanges: function() {
 			var model = this._model = chartHelpers.clone(this._model) || {};
+			var options = this.options;
 
+			// Set the data range for this annotation
 			model.ranges = {};
 			model.ranges[options.scaleID] = {
 				min: options.value,
 				max: options.endValue || options.value
 			};
 		},
-		configure: function(options, chartInstance) {
+		configure: function() {
 			var model = this._model = chartHelpers.clone(this._model) || {};
+			var options = this.options;
+			var chartInstance = this.chartInstance;
 
 			var scale = chartInstance.scales[options.scaleID];
 			var pixel, endPixel;
@@ -85,8 +89,9 @@ module.exports = function(Chart) {
 			model.borderDash = options.borderDash || [];
 			model.borderDashOffset = options.borderDashOffset || 0;
 		},
-		draw: function(ctx) {
+		draw: function() {
 			var view = this._view;
+			var ctx = this.ctx;
 
 			// Canvas setup
 			ctx.save();

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -33,8 +33,11 @@ module.exports = function(Chart) {
 				endPixel = helpers.isValid(options.endValue) ? scale.getPixelForValue(options.endValue) : pixel;
 			}
 
+			if (isNaN(pixel)) {
+				return;
+			}
+
 			var chartArea = chartInstance.chartArea;
-			var ctx = chartInstance.chart.ctx;
 
 			// clip annotations to the chart area
 			model.clip = {
@@ -44,18 +47,16 @@ module.exports = function(Chart) {
 				y2: chartArea.bottom
 			};
 
-			if (!isNaN(pixel)) {
-				if (options.mode == horizontalKeyword) {
-					model.x1 = chartArea.left;
-					model.x2 = chartArea.right;
-					model.y1 = pixel;
-					model.y2 = endPixel;
-				} else {
-					model.y1 = chartArea.top;
-					model.y2 = chartArea.bottom;
-					model.x1 = pixel;
-					model.x2 = endPixel;
-				}
+			if (this.options.mode == horizontalKeyword) {
+				model.x1 = chartArea.left;
+				model.x2 = chartArea.right;
+				model.y1 = pixel;
+				model.y2 = endPixel;
+			} else {
+				model.y1 = chartArea.top;
+				model.y2 = chartArea.bottom;
+				model.x1 = pixel;
+				model.x2 = endPixel;
 			}
 
 			model.mode = options.mode;
@@ -92,6 +93,10 @@ module.exports = function(Chart) {
 		draw: function() {
 			var view = this._view;
 			var ctx = this.ctx;
+			
+			if (!view.clip) {
+				return;
+			}
 
 			// Canvas setup
 			ctx.save();


### PR DESCRIPTION
Add an array of the events that should be watched to the `annotation` config object, and a corresponding `on{Event}` function to each annotation. Event callbacks are passed the event object as the first argument, and the target element is bound to `this`.