### PR TITLE
Added alias pixel when using odd line widths in canvas

### DIFF
--- a/src/types/line.js
+++ b/src/types/line.js
@@ -131,6 +131,16 @@ module.exports = function(Chart) {
 			}
 			ctx.lineDashOffset = view.borderDashOffset;
 
+			var aliasPixel = Chart.helpers.aliasPixel(ctx.lineWidth);
+			if (view.mode === verticalKeyword) {
+				view.x1 += aliasPixel;
+				view.x2 += aliasPixel;
+			}
+			else {
+				view.y1 += aliasPixel;
+				view.y2 += aliasPixel;
+			}
+
 			// Draw
 			ctx.beginPath();
 			ctx.moveTo(view.x1, view.y1);


### PR DESCRIPTION
Using an odd line width results in crisp lines in canvas. Fixed by adding an alias pixel using helper function of chart js core.

For more information see [https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors#A_lineWidth_example)