### PR TITLE
Fix chartArea not yet available when calling setDataLimits

### DIFF
--- a/src/types/box.js
+++ b/src/types/box.js
@@ -12,6 +12,10 @@ module.exports = function(Chart) {
 			var yScale = chartInstance.scales[options.yScaleID];
 			var chartArea = chartInstance.chartArea;
 
+			if (!chartArea) {
+				return;
+			}
+
 			// Set the data range for this annotation
 			model.ranges = {};
 


### PR DESCRIPTION
```
angular.js:14199 TypeError: Cannot read property 'left' of undefined
    at ChartElement.setDataLimits (https://localhost:8003/bower_components/chartjs-plugin-annotation/chartjs-plugin-annotation.js:517:91)
    at ChartElement.initialize (https://localhost:8003/bower_components/chartjs-plugin-annotation/chartjs-plugin-annotation.js:139:9)
    at ChartElement.Chart.Element (https://localhost:8003/bower_components/chart.js/dist/Chart.js:4899:19)
    at ChartElement [as constructor] (https://localhost:8003/bower_components/chart.js/dist/Chart.js:5193:14)
    at new ChartElement (https://localhost:8003/bower_components/chart.js/dist/Chart.js:5193:14)
    at https://localhost:8003/bower_components/chartjs-plugin-annotation/chartjs-plugin-annotation.js:69:20
    at Array.forEach (native)
    at Object.beforeUpdate (https://localhost:8003/bower_components/chartjs-plugin-annotation/chartjs-plugin-annotation.js:63:27)
    at Object.notify (https://localhost:8003/bower_components/chart.js/dist/Chart.js:7346:17)
    at Chart.Controller.update (https://localhost:8003/bower_components/chart.js/dist/Chart.js:4136:16)
```