### PR TITLE
Declare variables to comply to 'use strict'

### DIFF
--- a/src/types/box.js
+++ b/src/types/box.js
@@ -14,7 +14,10 @@ module.exports = function(Chart) {
 
 			// Set the data range for this annotation
 			model.ranges = {};
-
+			
+			var min = 0;
+			var max = 0;
+			
 			if (xScale) {
 				min = helpers.isValid(options.xMin) ? options.xMin : xScale.getPixelForValue(chartArea.left);
 				max = helpers.isValid(options.xMax) ? options.xMax : xScale.getPixelForValue(chartArea.right);


### PR DESCRIPTION
Otherwise, the plugin cannot be bundled with 'use strict'