### PR TITLE
Fix error on creating box annotation with missing min or max param

### DIFF
--- a/src/types/box.js
+++ b/src/types/box.js
@@ -12,12 +12,12 @@ module.exports = function(Chart) {
 			var yScale = chartInstance.scales[options.yScaleID];
 			var chartArea = chartInstance.chartArea;
 
+			// Set the data range for this annotation
+			model.ranges = {};
+			
 			if (!chartArea) {
 				return;
 			}
-
-			// Set the data range for this annotation
-			model.ranges = {};
 			
 			var min = 0;
 			var max = 0;


### PR DESCRIPTION
You can see the issue here: https://codepen.io/anon/pen/EvggZy.

Basically when creating an annotation like this:
```
{
            drawTime: "beforeDatasetsDraw",
            type: "box",
            yScaleID: "y-axis-0",
            yMin: 0,
            // yMax: -10, <------ uncomment this to make it work!
            backgroundColor: "rgba(101, 33, 171, 0.5)",
}
```

without specifying for example the `yMax` parameter, it throws an error on missing chartInstance object. I understand that there may be another problem why chartInstance is missing but this fixes the error and makes it work.

PS: I've already merged PR #65 in this one but needed to update the code position. Thanks