### PR TITLE
move configure step to draw time, to support render call

### DIFF
--- a/src/annotation.js
+++ b/src/annotation.js
@@ -24,7 +24,8 @@ module.exports = function(Chart) {
 					return drawTime === (element.options.drawTime || defaultDrawTime);
 				})
 				.forEach(function(element) {
-					element.transition(easingDecimal).draw();
+                    element.configure();
+                    element.transition(easingDecimal).draw();
 				});
 		};
 	}
@@ -94,11 +95,6 @@ module.exports = function(Chart) {
 					ns.elements[id].destroy();
 					delete ns.elements[id];
 				}
-			});
-		},
-		afterScaleUpdate: function(chartInstance) {
-			helpers.elements(chartInstance).forEach(function(element) {
-				element.configure();
 			});
 		},
 		beforeDatasetsDraw: draw('beforeDatasetsDraw'),

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -24,8 +24,8 @@ module.exports = function(Chart) {
 					return drawTime === (element.options.drawTime || defaultDrawTime);
 				})
 				.forEach(function(element) {
-                    element.configure();
-                    element.transition(easingDecimal).draw();
+					element.configure();
+					element.transition(easingDecimal).draw();
 				});
 		};
 	}


### PR DESCRIPTION
Chart.js has a [`render`](https://www.chartjs.org/docs/latest/developers/api.html#renderconfig) function in addition to `update`. Unlike `update`, calling `render` does not recalculate the layout and update datasets, so it is far more performant in cases where only config or plugins have to be updated. However, `render` does not invoke the `afterScaleUpdate` hook, so calling `render` with an updated annotation config will not update the annotation, since `element.configure()` takes place in the `afterScaleUpdate` hook. 

To remedy this, I've moved the `element.configure()` call to within the draw function, so that it still gets called when `render` is called. This means that, in scenarios when only annotations need to be updated, we can now call `render` instead of `update` for a significant speedup in situations where layout or dataset updates are expensive.