### PR TITLE
Added PLUGIN ID because missing

### DIFF
--- a/src/annotation.js
+++ b/src/annotation.js
@@ -40,7 +40,6 @@ module.exports = function(Chart) {
 
 	return {
 		id: 'annotation',
-				
 		beforeInit: function(chartInstance) {
 			var chartOptions = chartInstance.options;
 

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -39,6 +39,8 @@ module.exports = function(Chart) {
 	}
 
 	return {
+		id: 'annotation',
+				
 		beforeInit: function(chartInstance) {
 			var chartOptions = chartInstance.options;
 


### PR DESCRIPTION
Added PLUGIN ID 'annotation" in order to register into Chart.js as required like best practise.
In this way you could disable in some chart instances, if you want