### PR TITLE
"preserveComments" no longer available on gulp-uglify

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ var gulp = require('gulp'),
 var srcDir = './src/';
 var outDir = './';
 
-var header = "/*!\n\
+var header = "/*@preserve!\n\
  * chartjs-plugin-annotation.js\n\
  * http://chartjs.org/\n\
  * Version: {{ version }}\n\
@@ -46,9 +46,9 @@ function buildTask() {
     .pipe(insert.prepend(header))
     .pipe(streamify(replace('{{ version }}', package.version)))
     .pipe(gulp.dest(outDir))
-    .pipe(streamify(uglify({
-      preserveComments: 'some'
-    })))
+    .pipe(streamify(uglify({ output: {
+      comments: 'some'
+    }})))
     .pipe(streamify(concat('chartjs-plugin-annotation.min.js')))
     .pipe(gulp.dest(outDir));
 


### PR DESCRIPTION
Building the project, you get an error because "preserveComments" is not longer supported (see [here](https://github.com/terinjokes/gulp-uglify/releases/tag/v3.0.0)).
Added tag @preserver and new gulp-uglify option to support to maintain the header into minify file