### PR TITLE
Add rotation option for line labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,10 @@ Vertical or horizontal lines are supported.
 		enabled: false,
 
 		// Text to display in label - default is null. Provide an array to display values on a new line
-		content: "Test label"
+		content: "Test label",
+
+		// Rotation of label, in degrees, default is 0
+		rotation: 90
 	},
 
 	// Mouse event handlers - be sure to enable the corresponding events in the

--- a/samples/bar.html
+++ b/samples/bar.html
@@ -113,6 +113,24 @@
 								console.log('Annotation', e.type, this);
 							}
 						}, {
+							id: 'vline-rotated',
+							type: 'line',
+							mode: 'vertical',
+							scaleID: 'x-axis-0',
+							value: 'June',
+							borderColor: 'black',
+							borderWidth: 5,
+							label: {
+								backgroundColor: 'red',
+								content: 'Test Label',
+								enabled: true,
+								rotation: -90
+							},
+							onClick: function(e) {
+								// The annotation is is bound to the `this` variable
+								console.log('Annotation', e.type, this);
+							}
+						}, {
 							drawTime: 'beforeDatasetsDraw',
 							type: 'box',
 							xScaleID: 'x-axis-0',

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -154,6 +154,7 @@ module.exports = function(Chart) {
 			model.labelYAdjust = options.label.yAdjust;
 			model.labelEnabled = options.label.enabled;
 			model.labelContent = options.label.content;
+			model.labelRotation = options.label.rotation;
 
 			ctx.font = chartHelpers.fontString(model.labelFontSize, model.labelFontStyle, model.labelFontFamily);
 			var textWidth = ctx.measureText(model.labelContent).width;
@@ -248,12 +249,15 @@ module.exports = function(Chart) {
 				ctx.rect(view.clip.x1, view.clip.y1, view.clip.x2 - view.clip.x1, view.clip.y2 - view.clip.y1);
 				ctx.clip();
 
+				ctx.translate(view.labelX + (view.labelWidth / 2), view.labelY + (view.labelHeight / 2));
+				ctx.rotate(view.labelRotation * Math.PI / 180);
+
 				ctx.fillStyle = view.labelBackgroundColor;
 				// Draw the tooltip
 				chartHelpers.drawRoundedRectangle(
 					ctx,
-					view.labelX, // x
-					view.labelY, // y
+					-(view.labelWidth / 2), // x
+					-(view.labelHeight / 2), // y
 					view.labelWidth, // width
 					view.labelHeight, // height
 					view.labelCornerRadius // radius
@@ -270,12 +274,12 @@ module.exports = function(Chart) {
 				ctx.textAlign = 'center';
 
 				if (view.labelContent && chartHelpers.isArray(view.labelContent)) {
-					var textYPosition = view.labelY + view.labelYPadding;
+					var textYPosition = -(view.labelHeight / 2) + view.labelYPadding;
 					for (var i = 0; i < view.labelContent.length; i++) {
 						ctx.textBaseline = 'top';
 						ctx.fillText(
 							view.labelContent[i],
-							view.labelX + (view.labelWidth / 2),
+							-(view.labelWidth / 2) + (view.labelWidth / 2),
 							textYPosition
 						);
 
@@ -283,11 +287,7 @@ module.exports = function(Chart) {
 					}
 				} else {
 					ctx.textBaseline = 'middle';
-					ctx.fillText(
-						view.labelContent,
-						view.labelX + (view.labelWidth / 2),
-						view.labelY + (view.labelHeight / 2)
-					);
+					ctx.fillText(view.labelContent, 0, 0);
 				}
 			}
 


### PR DESCRIPTION
Hi,

I added a parameter `rotate` for line labels. As it is named, this parameter allows to rotate the label. I needed this feature to display the label of a vertical line along the line (ie the label is vertical too).

I updated the sample _bar_ to add a demo of this feature.