### PR TITLE
Fix destroying annotations and beforeDatasetsDraw

### DIFF
--- a/src/annotation.js
+++ b/src/annotation.js
@@ -24,7 +24,7 @@ export default {
 		updateElements(chart, options, args.mode);
 	},
 
-	beforeDatasetDraw(chart, options) {
+	beforeDatasetsDraw(chart, options) {
 		draw(chart, options, 'beforeDatasetsDraw');
 	},
 

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -44,7 +44,7 @@ export default {
 	},
 
 	destroy(chart) {
-		chartElements.remove(chart);
+		chartElements.delete(chart);
 	},
 
 	defaults: {


### PR DESCRIPTION
JS Maps use `delete`, not `remove`.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete

The code mistakenly used beforeDatasetDraw (singular), which caused the annotations to be drawn for every dataset, instead of being drawn once before all datasets.