### PR TITLE
`display` setting for annotation

### DIFF
--- a/samples/bar.html
+++ b/samples/bar.html
@@ -109,7 +109,7 @@
 							}, {
 								type: 'line',
 								mode: 'vertical',
-								display: function(chart, options) {
+								display(chart) {
 									return chart.data.datasets.length > 0 ? chart.isDatasetVisible(0) : false;
 								},
 								scaleID: 'x',
@@ -125,7 +125,7 @@
 							}, {
 								drawTime: 'beforeDatasetsDraw',
 								type: 'box',
-								display: function(chart, options) {
+								display(chart) {
 									return chart.data.datasets.length > 1 ? chart.isDatasetVisible(1) : false;
 								},
 								xScaleID: 'x',

--- a/samples/bar.html
+++ b/samples/bar.html
@@ -109,6 +109,9 @@
 							}, {
 								type: 'line',
 								mode: 'vertical',
+								display: function(chart, options) {
+									return chart.data.datasets.length > 0 ? chart.isDatasetVisible(0) : false;
+								},
 								scaleID: 'x',
 								value: 'June',
 								borderColor: 'black',
@@ -122,6 +125,9 @@
 							}, {
 								drawTime: 'beforeDatasetsDraw',
 								type: 'box',
+								display: function(chart, options) {
+									return chart.data.datasets.length > 1 ? chart.isDatasetVisible(1) : false;
+								},
 								xScaleID: 'x',
 								yScaleID: 'y',
 								xMin: 'February',
@@ -151,7 +157,7 @@
 		const colorNames = Object.keys(window.chartColors);
 		document.getElementById('addDataset').addEventListener('click', () => {
 			const colorName = colorNames[barChartData.datasets.length % colorNames.length];
-	const dsColor = window.chartColors[colorName];
+			const dsColor = window.chartColors[colorName];
 			const newDataset = {
 				label: 'Dataset ' + barChartData.datasets.length,
 				backgroundColor: color(dsColor).alpha(0.5).rgbString(),

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -76,13 +76,6 @@ const directUpdater = {
 	update: Object.assign
 };
 
-function resolveDisplay(state, options) {
-	const annotations = options.annotations || [];
-	annotations.forEach(annotation => {
-		console.log(annotation);
-	});
-}
-
 function resolveAnimations(chart, animOpts, mode) {
 	if (mode === 'reset' || mode === 'none' || mode === 'resize') {
 		return directUpdater;
@@ -99,7 +92,7 @@ function updateElements(chart, state, options, mode) {
 	const annotations = options.annotations || [];
 	const count = annotations.length;
 	const start = elements.length;
-	
+
 	if (start < count) {
 		const add = count - start;
 		elements.splice(start, 0, ...new Array(add));
@@ -114,8 +107,8 @@ function updateElements(chart, state, options, mode) {
 			el = elements[i] = new elType();
 		}
 		const display = typeof annotation.display === 'function' ? callCallback(annotation.display, [chart, annotation], this) : valueOrDefault(annotation.display, true);
-		el._display = typeof display === 'boolean' ? display : false;
-		
+		el._display = !!display;
+
 		const properties = calculateElementProperties(chart, annotation, elType.defaults);
 		animations.update(el, properties);
 	}
@@ -182,7 +175,7 @@ function draw(chart, options, caller) {
 	clipArea(ctx, chartArea);
 	for (let i = 0; i < elements.length; i++) {
 		const el = elements[i];
-		if ((el.options.drawTime || options.drawTime || caller) === caller && el._display) {
+		if (el._display && (el.options.drawTime || options.drawTime || caller) === caller) {
 			el.draw(ctx);
 		}
 	}

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -248,4 +248,3 @@ function getScaleLimits(scale, annotations) {
 	});
 	return {min, max};
 }
-

--- a/src/types/box.js
+++ b/src/types/box.js
@@ -37,6 +37,7 @@ export default class BoxAnnotation extends Element {
 BoxAnnotation.id = 'boxAnnotation';
 
 BoxAnnotation.defaults = {
+	display: true,
 	borderWidth: 1
 };
 

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -78,6 +78,7 @@ export default class LineAnnotation extends Element {
 
 LineAnnotation.id = 'lineAnnotation';
 LineAnnotation.defaults = {
+	display: true,
 	borderDash: [],
 	borderDashOffset: 0,
 	label: {


### PR DESCRIPTION
Fixes #244.

Adds display property to the annotation element options (both box and line). The default is `true`.

```javascript
plugins: {
   annotation: {
      annotations: [{
         type: 'line',
         display: false,  // <-- new option, default is true
         scaleID: 'y',
         value: 10
      }]
   }
}
```

It can also set by a callback in order to hide the annotation using a logic related to chart or datasets status.

```javascript
plugins: {
   annotation: {
      annotations: [{
         type: 'line',
         display(chart, options) {
            // your logic, for instance the annoatation is shown 
            // only if a dataset (in this case the first one) is not hidden
            return chart.isDatasetVisible(0);
         },
         scaleID: 'y',
         value: 10
      }]
   }
}
```