### PR TITLE
Remove annotations array, using an object instead and min/max on value and endValue options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,26 +41,28 @@ To configure the annotations plugin, you can simply add new config options to yo
                 // context: {chart, element}
             },
 
-            // Array of annotation configuration objects
+            // Object with the annotation configuration objects, one for each key
             // See below for detailed descriptions of the annotation options
-            annotations: [{
-                drawTime: 'afterDraw', // overrides annotation.drawTime if set
-                type: 'line',
-                mode: 'horizontal',
-                scaleID: 'y',
-                value: '25',
-                borderColor: 'red',
-                borderWidth: 2,
+            annotations: {
+                myLine: {
+                    drawTime: 'afterDraw', // overrides annotation.drawTime if set
+                    type: 'line',
+                    mode: 'horizontal',
+                    scaleID: 'y',
+                    value: '25',
+                    borderColor: 'red',
+                    borderWidth: 2,
 
-                // Event hooks can be defined per annotation (`click` below) or
-                // at chart level (`enter` above). If defined in both places,
-                // the one defined per annotation takes precedence.
+                    // Event hooks can be defined per annotation (`click` below) or
+                    // at chart level (`enter` above). If defined in both places,
+                    // the one defined per annotation takes precedence.
 
-                // Fires when the user clicks this annotation on the chart
-                click: function(context) {
-                    // context: {chart, element}
+                    // Fires when the user clicks this annotation on the chart
+                    click: function(context) {
+                       // context: {chart, element}
+                    }
                 }
-            }]
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ To configure the annotations plugin, you can simply add new config options to yo
                 // context: {chart, element}
             },
 
-            // Object with the annotation configuration objects, one for each key
+            // Array of annotation configuration objects 
+            // or Object with the annotation configuration objects, one for each key
             // See below for detailed descriptions of the annotation options
-            annotations: {
-                myLine: {
+            annotations: [{
                     drawTime: 'afterDraw', // overrides annotation.drawTime if set
                     type: 'line',
                     mode: 'horizontal',
@@ -61,8 +61,7 @@ To configure the annotations plugin, you can simply add new config options to yo
                     click: function(context) {
                        // context: {chart, element}
                     }
-                }
-            }
+             }]
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -45,23 +45,23 @@ To configure the annotations plugin, you can simply add new config options to yo
             // or Object with the annotation configuration objects, one for each key
             // See below for detailed descriptions of the annotation options
             annotations: [{
-                    drawTime: 'afterDraw', // overrides annotation.drawTime if set
-                    type: 'line',
-                    mode: 'horizontal',
-                    scaleID: 'y',
-                    value: '25',
-                    borderColor: 'red',
-                    borderWidth: 2,
+                drawTime: 'afterDraw', // overrides annotation.drawTime if set
+                type: 'line',
+                mode: 'horizontal',
+                scaleID: 'y',
+                value: '25',
+                borderColor: 'red',
+                borderWidth: 2,
 
-                    // Event hooks can be defined per annotation (`click` below) or
-                    // at chart level (`enter` above). If defined in both places,
-                    // the one defined per annotation takes precedence.
+                // Event hooks can be defined per annotation (`click` below) or
+                // at chart level (`enter` above). If defined in both places,
+                // the one defined per annotation takes precedence.
 
-                    // Fires when the user clicks this annotation on the chart
-                    click: function(context) {
-                       // context: {chart, element}
-                    }
-             }]
+                // Fires when the user clicks this annotation on the chart
+                click: function(context) {
+                   // context: {chart, element}
+                }
+            }]
         }
     }
 }

--- a/samples/animation.html
+++ b/samples/animation.html
@@ -57,18 +57,20 @@
 				plugins: {
 					annotation: {
 						drawTime: 'afterDatasetsDraw',
-						annotations: [{
-							type: 'line',
-							borderWidth: 3,
-							scaleID: 'x',
-							value: 50,
-							borderColor: 'red',
-							label: {
-								rotation: 90,
-								content: 'annotation',
-								enabled: true,
-							},
-						}]
+						annotations: {
+							line: {
+								type: 'line',
+								borderWidth: 3,
+								scaleID: 'x',
+								value: 50,
+								borderColor: 'red',
+								label: {
+									rotation: 90,
+									content: 'annotation',
+									enabled: true,
+								},
+							}
+						}
 					}
 				}
 			}
@@ -78,7 +80,7 @@
 			const newval = +document.querySelector('input[type=range]').value;
 			myChart.data.datasets[0].data[1].x = newval;
 			myChart.data.datasets[0].data[2].x = newval;
-			myChart.options.plugins.annotation.annotations[0].value = newval;
+			myChart.options.plugins.annotation.annotations.line.value = newval;
 			myChart.update();
 		}
 	</script>

--- a/samples/bar.html
+++ b/samples/bar.html
@@ -83,65 +83,65 @@
 								console.log('Annotation', context);
 							},
 							annotations: {
-							  primo: {
-								type: 'line',
-								mode: 'horizontal',
-								scaleID: 'y',
-								value: randomScalingFactor(),
-								borderColor: 'black',
-								borderWidth: 5,
-								label: {
-									backgroundColor: 'red',
-									content: 'Test Label',
-									enabled: true
+								first: {
+									type: 'line',
+									mode: 'horizontal',
+									scaleID: 'y',
+									value: randomScalingFactor(),
+									borderColor: 'black',
+									borderWidth: 5,
+									label: {
+										backgroundColor: 'red',
+										content: 'Test Label',
+										enabled: true
+									},
 								},
-							  }, 
-							  secondo: {
-								type: 'line',
-								mode: 'vertical',
-								scaleID: 'x',
-								value: 'May',
-								borderColor: 'black',
-								borderWidth: 5,
-								label: {
-									backgroundColor: 'red',
-									content: 'Test Label',
-									enabled: true
+								second: {
+									type: 'line',
+									mode: 'vertical',
+									scaleID: 'x',
+									value: 'May',
+									borderColor: 'black',
+									borderWidth: 5,
+									label: {
+										backgroundColor: 'red',
+										content: 'Test Label',
+										enabled: true
+									},
 								},
-							  }, 
-							  terzo: {
-								type: 'line',
-								mode: 'vertical',
-								display(chart) {
-									return chart.data.datasets.length > 0 ? chart.isDatasetVisible(0) : false;
+								third: {
+									type: 'line',
+									mode: 'vertical',
+									display(chart) {
+										return chart.data.datasets.length > 0 ? chart.isDatasetVisible(0) : false;
+									},
+									scaleID: 'x',
+									value: 'June',
+									borderColor: 'black',
+									borderWidth: 5,
+									label: {
+										backgroundColor: 'red',
+										content: 'Test Label',
+										enabled: true,
+										rotation: -90
+									},
 								},
-								scaleID: 'x',
-								value: 'June',
-								borderColor: 'black',
-								borderWidth: 5,
-								label: {
-									backgroundColor: 'red',
-									content: 'Test Label',
-									enabled: true,
-									rotation: -90
-								},
-							}, 
-							quarto: {
-								drawTime: 'beforeDatasetsDraw',
-								type: 'box',
-								display(chart) {
-									return chart.data.datasets.length > 1 ? chart.isDatasetVisible(1) : false;
-								},
-								xScaleID: 'x',
-								yScaleID: 'y',
-								xMin: 'February',
-								xMax: 'April',
-								yMin: randomScalingFactor(),
-								yMax: randomScalingFactor(),
-								backgroundColor: 'rgba(101, 33, 171, 0.5)',
-								borderColor: 'rgb(101, 33, 171)',
-								borderWidth: 1,
-							}
+								fourth: {
+									drawTime: 'beforeDatasetsDraw',
+									type: 'box',
+									display(chart) {
+										return chart.data.datasets.length > 1 ? chart.isDatasetVisible(1) : false;
+									},
+									xScaleID: 'x',
+									yScaleID: 'y',
+									xMin: 'February',
+									xMax: 'April',
+									yMin: randomScalingFactor(),
+									yMax: randomScalingFactor(),
+									backgroundColor: 'rgba(101, 33, 171, 0.5)',
+									borderColor: 'rgb(101, 33, 171)',
+									borderWidth: 1,
+								}
 							}
 						}
 					}

--- a/samples/bar.html
+++ b/samples/bar.html
@@ -82,7 +82,8 @@
 							click(context) {
 								console.log('Annotation', context);
 							},
-							annotations: [{
+							annotations: {
+							  primo: {
 								type: 'line',
 								mode: 'horizontal',
 								scaleID: 'y',
@@ -94,7 +95,8 @@
 									content: 'Test Label',
 									enabled: true
 								},
-							}, {
+							  }, 
+							  secondo: {
 								type: 'line',
 								mode: 'vertical',
 								scaleID: 'x',
@@ -106,7 +108,8 @@
 									content: 'Test Label',
 									enabled: true
 								},
-							}, {
+							  }, 
+							  terzo: {
 								type: 'line',
 								mode: 'vertical',
 								display(chart) {
@@ -122,7 +125,8 @@
 									enabled: true,
 									rotation: -90
 								},
-							}, {
+							}, 
+							quarto: {
 								drawTime: 'beforeDatasetsDraw',
 								type: 'box',
 								display(chart) {
@@ -137,12 +141,12 @@
 								backgroundColor: 'rgba(101, 33, 171, 0.5)',
 								borderColor: 'rgb(101, 33, 171)',
 								borderWidth: 1,
-							}]
+							}
+							}
 						}
 					}
 				}
 			});
-
 		};
 
 		document.getElementById('randomizeData').addEventListener('click', () => {

--- a/samples/box.html
+++ b/samples/box.html
@@ -130,21 +130,23 @@
 					plugins: {
 						annotation: {
 							drawTime: 'afterDraw',
-							annotations: [{
-								type: 'box',
-								xScaleID: 'x',
-								yScaleID: 'y',
-								xMin: -120,
-								xMax: 20,
-								yMin: -120,
-								yMax: 20,
-								backgroundColor: 'rgba(101, 33, 171, 0.5)',
-								borderColor: 'rgb(101, 33, 171)',
-								borderWidth: 1,
-								click(context) {
-									console.log('Annotation', context);
-								},
-							}]
+							annotations: {
+								box: {
+									type: 'box',
+									xScaleID: 'x',
+									yScaleID: 'y',
+									xMin: -120,
+									xMax: 20,
+									yMin: -120,
+									yMax: 20,
+									backgroundColor: 'rgba(101, 33, 171, 0.5)',
+									borderColor: 'rgb(101, 33, 171)',
+									borderWidth: 1,
+									click(context) {
+										console.log('Annotation', context);
+									}
+								}
+							}
 						}
 					}
 				}

--- a/samples/bubble.html
+++ b/samples/bubble.html
@@ -121,21 +121,23 @@
 					plugins: {
 						annotation: {
 							drawTime: 'beforeDatasetsDraw',
-							annotations: [{
-								type: 'box',
-								xScaleID: 'x',
-								yScaleID: 'y',
-								xMin: randomScalingFactor(),
-								xMax: randomScalingFactor(),
-								yMin: randomScalingFactor(),
-								yMax: randomScalingFactor(),
-								backgroundColor: 'rgba(101, 33, 171, 0.5)',
-								borderColor: 'rgb(101, 33, 171)',
-								borderWidth: 1,
-								dblclick(context) {
-									console.log('Box', context);
+							annotations: {
+								box: {
+									type: 'box',
+									xScaleID: 'x',
+									yScaleID: 'y',
+									xMin: randomScalingFactor(),
+									xMax: randomScalingFactor(),
+									yMin: randomScalingFactor(),
+									yMax: randomScalingFactor(),
+									backgroundColor: 'rgba(101, 33, 171, 0.5)',
+									borderColor: 'rgb(101, 33, 171)',
+									borderWidth: 1,
+									dblclick(context) {
+										console.log('Box', context);
+									}
 								}
-							}]
+							}
 						}
 					}
 				}

--- a/samples/bubble.html
+++ b/samples/bubble.html
@@ -121,8 +121,8 @@
 					plugins: {
 						annotation: {
 							drawTime: 'beforeDatasetsDraw',
-							annotations: {
-								box: {
+							annotations: [
+								{
 									type: 'box',
 									xScaleID: 'x',
 									yScaleID: 'y',
@@ -137,7 +137,7 @@
 										console.log('Box', context);
 									}
 								}
-							}
+							]
 						}
 					}
 				}

--- a/samples/combo-bar-line.html
+++ b/samples/combo-bar-line.html
@@ -89,32 +89,35 @@
 							click(context) {
 								console.log('Annotation', context);
 							},
-							annotations: [{
-								drawTime: 'afterDatasetsDraw',
-								type: 'line',
-								mode: 'horizontal',
-								scaleID: 'y',
-								value: randomScalingFactor(),
-								borderColor: 'black',
-								borderWidth: 5,
-								label: {
-									backgroundColor: 'red',
-									content: 'Test Label',
-									enabled: true
-								},
-							}, {
-								drawTime: 'beforeDatasetsDraw',
-								type: 'box',
-								xScaleID: 'x',
-								yScaleID: 'y',
-								xMin: 'February',
-								xMax: 'April',
-								yMin: randomScalingFactor(),
-								yMax: randomScalingFactor(),
-								backgroundColor: 'rgba(101, 33, 171, 0.5)',
-								borderColor: 'rgb(101, 33, 171)',
-								borderWidth: 1,
-							}]
+							annotations: {
+								myLine: {
+									drawTime: 'afterDatasetsDraw',
+									type: 'line',
+									mode: 'horizontal',
+									scaleID: 'y',
+									value: randomScalingFactor(),
+									borderColor: 'black',
+									borderWidth: 5,
+									label: {
+										backgroundColor: 'red',
+										content: 'Test Label',
+										enabled: true
+									},
+								}, 
+								myBox: {
+									drawTime: 'beforeDatasetsDraw',
+									type: 'box',
+									xScaleID: 'x',
+									yScaleID: 'y',
+									xMin: 'February',
+									xMax: 'April',
+									yMin: randomScalingFactor(),
+									yMax: randomScalingFactor(),
+									backgroundColor: 'rgba(101, 33, 171, 0.5)',
+									borderColor: 'rgb(101, 33, 171)',
+									borderWidth: 1,
+								}
+							}
 						}
 					}
 				}

--- a/samples/combo-bar-line.html
+++ b/samples/combo-bar-line.html
@@ -103,7 +103,7 @@
 										content: 'Test Label',
 										enabled: true
 									},
-								}, 
+								},
 								myBox: {
 									drawTime: 'beforeDatasetsDraw',
 									type: 'box',

--- a/samples/horizontal-line.html
+++ b/samples/horizontal-line.html
@@ -129,60 +129,62 @@
 					},
 					plugins: {
 						annotation: {
-							annotations: [{
-								type: 'line',
-								mode: 'horizontal',
-								scaleID: 'y',
-								value: 120,
-								borderColor: 'rgba(255, 0, 0, 0.5)',
-								borderWidth: 4,
-								label: {
-									enabled: false,
-									content: 'Test label'
-								},
-								click(context) {
-									const element = context.element;
-									element.options.borderColor = 'rgba(255, 0, 0, 1.0)';
-									element.options.label.enabled = true;
-									element.options.label.content = 'click';
-									context.chart.draw();
-									setTimeout(() => {
-										element.options.borderColor = 'rgba(255, 0, 0, 0.5)';
+							annotations: {
+								myLine : {
+									type: 'line',
+									mode: 'horizontal',
+									scaleID: 'y',
+									value: 120,
+									borderColor: 'rgba(255, 0, 0, 0.5)',
+									borderWidth: 4,
+									label: {
+										enabled: false,
+										content: 'Test label'
+									},
+									click(context) {
+										const element = context.element;
+										element.options.borderColor = 'rgba(255, 0, 0, 1.0)';
+										element.options.label.enabled = true;
+										element.options.label.content = 'click';
 										context.chart.draw();
-									}, 500);
-								},
-								dblclick(context) {
-									const element = context.element;
-									element.options.borderColor = 'rgba(0, 255, 0, 1.0)';
-									element.options.label.enabled = true;
-									element.options.label.content = 'dblclick';
-									context.chart.draw();
-									setTimeout(() => {
-										element.options.borderColor = 'rgba(255, 0, 0, 0.5)';
+										setTimeout(() => {
+											element.options.borderColor = 'rgba(255, 0, 0, 0.5)';
+											context.chart.draw();
+										}, 500);
+									},
+									dblclick(context) {
+										const element = context.element;
+										element.options.borderColor = 'rgba(0, 255, 0, 1.0)';
+										element.options.label.enabled = true;
+										element.options.label.content = 'dblclick';
 										context.chart.draw();
-									}, 500);
-								},
-								enter(context) {
-									const element = context.element;
-									element.options.borderWidth = 7;
-									element.options.label.enabled = true;
-									element.options.label.content = 'enter';
-									context.chart.draw();
-									context.chart.canvas.style.cursor = 'pointer';
-								},
-								leave(context) {
-									const element = context.element;
-									element.options.borderWidth = 4;
-									element.options.label.enabled = true;
-									element.options.label.content = 'leave';
-									context.chart.draw();
-									setTimeout(() => {
-										element.options.label.enabled = false;
+										setTimeout(() => {
+											element.options.borderColor = 'rgba(255, 0, 0, 0.5)';
+											context.chart.draw();
+										}, 500);
+									},
+									enter(context) {
+										const element = context.element;
+										element.options.borderWidth = 7;
+										element.options.label.enabled = true;
+										element.options.label.content = 'enter';
 										context.chart.draw();
-									}, 500);
-									context.chart.canvas.style.cursor = 'initial';
+										context.chart.canvas.style.cursor = 'pointer';
+									},
+									leave(context) {
+										const element = context.element;
+										element.options.borderWidth = 4;
+										element.options.label.enabled = true;
+										element.options.label.content = 'leave';
+										context.chart.draw();
+										setTimeout(() => {
+											element.options.label.enabled = false;
+											context.chart.draw();
+										}, 500);
+										context.chart.canvas.style.cursor = 'initial';
+									}
 								}
-							}]
+							}
 						}
 					}
 				}

--- a/samples/horizontal-line.html
+++ b/samples/horizontal-line.html
@@ -130,7 +130,7 @@
 					plugins: {
 						annotation: {
 							annotations: {
-								myLine : {
+								myLine: {
 									type: 'line',
 									mode: 'horizontal',
 									scaleID: 'y',

--- a/samples/labels.html
+++ b/samples/labels.html
@@ -133,43 +133,45 @@
 					},
 					plugins: {
 						annotation: {
-							annotations: [{
-								type: 'line',
-								mode: 'horizontal',
-								scaleID: 'y',
-								value: 25,
-								borderColor: 'black',
-								borderWidth: 5,
-								label: {
-									yAdjust: -20,
-									backgroundColor: 'red',
-									content: 'This is a long test label',
-									enabled: true
+							annotations: {
+								myHorizontalLine: {
+									type: 'line',
+									mode: 'horizontal',
+									scaleID: 'y',
+									value: 25,
+									borderColor: 'black',
+									borderWidth: 5,
+									label: {
+										yAdjust: -20,
+										backgroundColor: 'red',
+										content: 'This is a long test label',
+										enabled: true
+									},
+									click(context) {
+										// The annotation is is bound to the `this` variable
+										console.log('Annotation', context);
+									}
 								},
-								click(context) {
-									// The annotation is is bound to the `this` variable
-									console.log('Annotation', context);
+								myVerticalLine: {
+									type: 'line',
+									mode: 'vertical',
+									scaleID: 'x',
+									value: 25,
+									endValue: 45,
+									borderColor: 'red',
+									borderWidth: 5,
+									label: {
+										position: 'bottom',
+										yAdjust: 100,
+										content: 'This is another test label',
+										enabled: true
+									},
+									click(context) {
+										// The annotation is is bound to the `this` variable
+										console.log('Annotation', context);
+									}
 								}
-							},
-							{
-								type: 'line',
-								mode: 'vertical',
-								scaleID: 'x',
-								value: 25,
-								endValue: 45,
-								borderColor: 'red',
-								borderWidth: 5,
-								label: {
-									position: 'bottom',
-									yAdjust: 100,
-									content: 'This is another test label',
-									enabled: true
-								},
-								click(context) {
-									// The annotation is is bound to the `this` variable
-									console.log('Annotation', context);
-								}
-							}]
+							}
 						}
 					}
 				}

--- a/samples/line-logarithmic.html
+++ b/samples/line-logarithmic.html
@@ -76,56 +76,60 @@
 				},
 				plugins: {
 					annotation: {
-						annotations: [{
-							drawTime: 'afterDraw',
-							type: 'line',
-							mode: 'horizontal',
-							scaleID: 'y',
-							value: randomScalingFactor(),
-							borderColor: 'black',
-							borderWidth: 5,
-							label: {
-								backgroundColor: 'red',
-								content: 'Test Label',
-								enabled: true
+						annotations: {
+							myHorizontalLine: {
+								drawTime: 'afterDraw',
+								type: 'line',
+								mode: 'horizontal',
+								scaleID: 'y',
+								value: randomScalingFactor(),
+								borderColor: 'black',
+								borderWidth: 5,
+								label: {
+									backgroundColor: 'red',
+									content: 'Test Label',
+									enabled: true
+								},
+								click(context) {
+									// The annotation is is bound to the `this` variable
+									console.log('Annotation', context);
+								}
+							}, 
+							myVerticalLine: {
+								drawTime: 'afterDraw',
+								type: 'line',
+								mode: 'vertical',
+								scaleID: 'x',
+								value: 'May',
+								borderColor: 'black',
+								borderWidth: 5,
+								label: {
+									backgroundColor: 'red',
+									content: 'Test Label',
+									enabled: true
+								},
+								click(context) {
+									// The annotation is is bound to the `this` variable
+									console.log('Annotation', context);
+								}
 							},
-							click(context) {
-								// The annotation is is bound to the `this` variable
-								console.log('Annotation', context);
+							myBox: {
+								drawTime: 'beforeDatasetsDraw',
+								type: 'box',
+								xScaleID: 'x',
+								yScaleID: 'y',
+								xMin: 'February',
+								xMax: 'April',
+								yMin: randomScalingFactor(),
+								yMax: randomScalingFactor(),
+								backgroundColor: 'rgba(101, 33, 171, 0.5)',
+								borderColor: 'rgb(101, 33, 171)',
+								borderWidth: 1,
+								click(context) {
+									console.log('Box', context);
+								}
 							}
-						}, {
-							drawTime: 'afterDraw',
-							type: 'line',
-							mode: 'vertical',
-							scaleID: 'x',
-							value: 'May',
-							borderColor: 'black',
-							borderWidth: 5,
-							label: {
-								backgroundColor: 'red',
-								content: 'Test Label',
-								enabled: true
-							},
-							click(context) {
-								// The annotation is is bound to the `this` variable
-								console.log('Annotation', context);
-							}
-						}, {
-							drawTime: 'beforeDatasetsDraw',
-							type: 'box',
-							xScaleID: 'x',
-							yScaleID: 'y',
-							xMin: 'February',
-							xMax: 'April',
-							yMin: randomScalingFactor(),
-							yMax: randomScalingFactor(),
-							backgroundColor: 'rgba(101, 33, 171, 0.5)',
-							borderColor: 'rgb(101, 33, 171)',
-							borderWidth: 1,
-							click(context) {
-								console.log('Box', context);
-							}
-						}]
+						}
 					}
 				}
 			}

--- a/samples/line-logarithmic.html
+++ b/samples/line-logarithmic.html
@@ -94,7 +94,7 @@
 									// The annotation is is bound to the `this` variable
 									console.log('Annotation', context);
 								}
-							}, 
+							},
 							myVerticalLine: {
 								drawTime: 'afterDraw',
 								type: 'line',

--- a/samples/line-time-scale.html
+++ b/samples/line-time-scale.html
@@ -158,7 +158,7 @@
 									// eslint-disable-next-line no-console
 									console.log(context.element.options.id, context);
 								}
-							}, 
+							},
 							myBox: {
 								type: 'box',
 								xScaleID: 'x',

--- a/samples/line-time-scale.html
+++ b/samples/line-time-scale.html
@@ -122,56 +122,60 @@
 				plugins: {
 					annotation: {
 						drawTime: 'afterDatasetsDraw',
-						annotations: [{
-							type: 'line',
-							mode: 'horizontal',
-							scaleID: 'y',
-							value: randomScalingFactor(),
-							borderColor: 'black',
-							borderWidth: 5,
-							label: {
-								backgroundColor: 'red',
-								content: 'Test Label',
-								enabled: true
+						annotations: {
+							myHorizontalLine: {
+								type: 'line',
+								mode: 'horizontal',
+								scaleID: 'y',
+								value: randomScalingFactor(),
+								borderColor: 'black',
+								borderWidth: 5,
+								label: {
+									backgroundColor: 'red',
+									content: 'Test Label',
+									enabled: true
+								},
+								click(context) {
+									// The annotation is is bound to the `this` variable
+									// eslint-disable-next-line no-console
+									console.log(context.element.options.id, context);
+								}
 							},
-							click(context) {
-								// The annotation is is bound to the `this` variable
-								// eslint-disable-next-line no-console
-								console.log('Annotation', context);
+							myVerticalLine: {
+								type: 'line',
+								mode: 'vertical',
+								scaleID: 'x',
+								value: newDate(2),
+								borderColor: 'black',
+								borderWidth: 5,
+								label: {
+									backgroundColor: 'red',
+									content: 'Test Label',
+									enabled: true
+								},
+								click(context) {
+									// The annotation is is bound to the `this` variable
+									// eslint-disable-next-line no-console
+									console.log(context.element.options.id, context);
+								}
+							}, 
+							myBox: {
+								type: 'box',
+								xScaleID: 'x',
+								yScaleID: 'y',
+								xMin: newDate(1),
+								xMax: newDate(4),
+								yMin: randomScalingFactor(),
+								yMax: randomScalingFactor(),
+								backgroundColor: 'rgba(101, 33, 171, 0.5)',
+								borderColor: 'rgb(101, 33, 171)',
+								borderWidth: 1,
+								click(context) {
+									// eslint-disable-next-line no-console
+									console.log(context.element.options.id, context);
+								}
 							}
-						}, {
-							type: 'line',
-							mode: 'vertical',
-							scaleID: 'x',
-							value: newDate(2),
-							borderColor: 'black',
-							borderWidth: 5,
-							label: {
-								backgroundColor: 'red',
-								content: 'Test Label',
-								enabled: true
-							},
-							click(context) {
-								// The annotation is is bound to the `this` variable
-								// eslint-disable-next-line no-console
-								console.log('Annotation', context);
-							}
-						}, {
-							type: 'box',
-							xScaleID: 'x',
-							yScaleID: 'y',
-							xMin: newDate(1),
-							xMax: newDate(4),
-							yMin: randomScalingFactor(),
-							yMax: randomScalingFactor(),
-							backgroundColor: 'rgba(101, 33, 171, 0.5)',
-							borderColor: 'rgb(101, 33, 171)',
-							borderWidth: 1,
-							click(context) {
-								// eslint-disable-next-line no-console
-								console.log('Box', context);
-							}
-						}]
+						}
 					}
 				}
 			}

--- a/samples/pie.html
+++ b/samples/pie.html
@@ -53,21 +53,23 @@
 				plugins: {
 					annotation: { // not supported, and should not display or error
 						drawTime: 'beforeDatasetsDraw',
-						annotations: [{
-							type: 'box',
-							xScaleID: 'x',
-							yScaleID: 'y',
-							xMin: -120,
-							xMax: 20,
-							yMin: -120,
-							yMax: 20,
-							backgroundColor: 'rgba(101, 33, 171, 1.0)',
-							borderColor: 'rgb(101, 33, 171)',
-							borderWidth: 1,
-							dblclick(context) {
-								console.log('Box', context);
+						annotations: {
+							myBox: {
+								type: 'box',
+								xScaleID: 'x',
+								yScaleID: 'y',
+								xMin: -120,
+								xMax: 20,
+								yMin: -120,
+								yMax: 20,
+								backgroundColor: 'rgba(101, 33, 171, 1.0)',
+								borderColor: 'rgb(101, 33, 171)',
+								borderWidth: 1,
+								dblclick(context) {
+									console.log(context.element.options.id, context);
+								}
 							}
-						}]
+						}
 					}
 				}
 			}

--- a/samples/polar-area.html
+++ b/samples/polar-area.html
@@ -59,6 +59,7 @@
 			},
 			options: {
 				responsive: true,
+				aspectRatio: 2,
 				legend: {
 					position: 'right',
 				},
@@ -79,21 +80,23 @@
 				plugins: {
 					annotation: { // not supported, and should not display or error
 						drawTime: 'beforeDatasetsDraw',
-						annotations: [{
-							type: 'box',
-							xScaleID: 'x',
-							yScaleID: 'y',
-							xMin: -120,
-							xMax: 20,
-							yMin: -120,
-							yMax: 20,
-							backgroundColor: 'rgba(101, 33, 171, 1.0)',
-							borderColor: 'rgb(101, 33, 171)',
-							borderWidth: 1,
-							dblclick(context) {
-								console.log('Box', context);
+						annotations: {
+							myBox: {
+								type: 'box',
+								xScaleID: 'x',
+								yScaleID: 'y',
+								xMin: -120,
+								xMax: 20,
+								yMin: -120,
+								yMax: 20,
+								backgroundColor: 'rgba(101, 33, 171, 1.0)',
+								borderColor: 'rgb(101, 33, 171)',
+								borderWidth: 1,
+								dblclick(context) {
+									console.log('Box', context);
+								}
 							}
-						}]
+						}
 					}
 				}
 			}

--- a/samples/radar.html
+++ b/samples/radar.html
@@ -80,21 +80,23 @@
 				plugins: {
 					annotation: { // not supported, and should not display or error
 						drawTime: 'beforeDatasetsDraw',
-						annotations: [{
-							type: 'box',
-							xScaleID: 'x',
-							yScaleID: 'y',
-							xMin: randomScalingFactor(),
-							xMax: randomScalingFactor(),
-							yMin: randomScalingFactor(),
-							yMax: randomScalingFactor(),
-							backgroundColor: 'rgba(101, 33, 171, 0.5)',
-							borderColor: 'rgb(101, 33, 171)',
-							borderWidth: 1,
-							dblclick(context) {
-								console.log('Box', context);
+						annotations: {
+							myBox: {
+								type: 'box',
+								xScaleID: 'x',
+								yScaleID: 'y',
+								xMin: randomScalingFactor(),
+								xMax: randomScalingFactor(),
+								yMin: randomScalingFactor(),
+								yMax: randomScalingFactor(),
+								backgroundColor: 'rgba(101, 33, 171, 0.5)',
+								borderColor: 'rgb(101, 33, 171)',
+								borderWidth: 1,
+								dblclick(context) {
+									console.log('Box', context);
+								}
 							}
-						}]
+						}
 					}
 				}
 			}

--- a/samples/updates.html
+++ b/samples/updates.html
@@ -154,7 +154,7 @@
 		};
 
 		function addLine() {
-			const id = 'myHorizontlLine'+(++counter);
+			const id = 'myHorizontlLine' + (++counter);
 			window.myScatter.options.plugins.annotation.annotations[id] = {
 				type: 'line',
 				mode: 'horizontal',
@@ -168,7 +168,7 @@
 
 		function removeLine() {
 			if (counter >= 0) {
-				const id = 'myHorizontlLine'+(counter--);
+				const id = 'myHorizontlLine' + (counter--);
 				delete window.myScatter.options.plugins.annotation.annotations[id];
 				window.myScatter.update();
 			}

--- a/samples/updates.html
+++ b/samples/updates.html
@@ -93,7 +93,7 @@
 		});
 
 		const lines = {
-			myHorizontlLine: {
+			myHorizontlLine0: {
 				type: 'line',
 				mode: 'horizontal',
 				scaleID: 'y',
@@ -102,6 +102,7 @@
 				borderWidth: 5
 			}
 		};
+		let counter = 0;
 
 		window.onload = function() {
 			const ctx = document.getElementById('canvas').getContext('2d');
@@ -153,7 +154,9 @@
 		};
 
 		function addLine() {
-			window.myScatter.options.plugins.annotation.annotations.myHorizontlLine = {
+			let id = 'myHorizontlLine'+(++counter);
+			console.log(id, counter);
+			window.myScatter.options.plugins.annotation.annotations[id] = {
 				type: 'line',
 				mode: 'horizontal',
 				scaleID: 'y',
@@ -165,8 +168,11 @@
 		}
 
 		function removeLine() {
-			window.myScatter.options.plugins.annotation.annotations.myHorizontlLine = null;
-			window.myScatter.update();
+			if (counter >= 0){
+				let id = 'myHorizontlLine'+(counter--);
+				delete window.myScatter.options.plugins.annotation.annotations[id];
+				window.myScatter.update();
+			}
 		}
 	</script>
 </body>

--- a/samples/updates.html
+++ b/samples/updates.html
@@ -154,8 +154,7 @@
 		};
 
 		function addLine() {
-			let id = 'myHorizontlLine'+(++counter);
-			console.log(id, counter);
+			const id = 'myHorizontlLine'+(++counter);
 			window.myScatter.options.plugins.annotation.annotations[id] = {
 				type: 'line',
 				mode: 'horizontal',
@@ -168,8 +167,8 @@
 		}
 
 		function removeLine() {
-			if (counter >= 0){
-				let id = 'myHorizontlLine'+(counter--);
+			if (counter >= 0) {
+				const id = 'myHorizontlLine'+(counter--);
 				delete window.myScatter.options.plugins.annotation.annotations[id];
 				window.myScatter.update();
 			}

--- a/samples/updates.html
+++ b/samples/updates.html
@@ -92,17 +92,14 @@
 			dataset.pointBorderWidth = 1;
 		});
 
-		const lines = {
-			myHorizontlLine0: {
-				type: 'line',
-				mode: 'horizontal',
-				scaleID: 'y',
-				value: randomScalingFactor() + 50,
-				borderColor: randomColor(0.75),
-				borderWidth: 5
-			}
-		};
-		let counter = 0;
+		const lines = [{
+			type: 'line',
+			mode: 'horizontal',
+			scaleID: 'y',
+			value: randomScalingFactor() + 50,
+			borderColor: randomColor(0.75),
+			borderWidth: 5
+		}];
 
 		window.onload = function() {
 			const ctx = document.getElementById('canvas').getContext('2d');
@@ -154,24 +151,20 @@
 		};
 
 		function addLine() {
-			const id = 'myHorizontlLine' + (++counter);
-			window.myScatter.options.plugins.annotation.annotations[id] = {
+			window.myScatter.options.plugins.annotation.annotations.push({
 				type: 'line',
 				mode: 'horizontal',
 				scaleID: 'y',
 				value: randomScalingFactor(),
 				borderColor: randomColor(0.75),
 				borderWidth: 5
-			};
+			});
 			window.myScatter.update();
 		}
 
 		function removeLine() {
-			if (counter >= 0) {
-				const id = 'myHorizontlLine' + (counter--);
-				delete window.myScatter.options.plugins.annotation.annotations[id];
-				window.myScatter.update();
-			}
+			window.myScatter.options.plugins.annotation.annotations.pop();
+			window.myScatter.update();
 		}
 	</script>
 </body>

--- a/samples/updates.html
+++ b/samples/updates.html
@@ -92,14 +92,16 @@
 			dataset.pointBorderWidth = 1;
 		});
 
-		const lines = [{
-			type: 'line',
-			mode: 'horizontal',
-			scaleID: 'y',
-			value: randomScalingFactor() + 50,
-			borderColor: randomColor(0.75),
-			borderWidth: 5
-		}];
+		const lines = {
+			myHorizontlLine: {
+				type: 'line',
+				mode: 'horizontal',
+				scaleID: 'y',
+				value: randomScalingFactor() + 50,
+				borderColor: randomColor(0.75),
+				borderWidth: 5
+			}
+		};
 
 		window.onload = function() {
 			const ctx = document.getElementById('canvas').getContext('2d');
@@ -151,19 +153,19 @@
 		};
 
 		function addLine() {
-			window.myScatter.options.plugins.annotation.annotations.push({
+			window.myScatter.options.plugins.annotation.annotations.myHorizontlLine = {
 				type: 'line',
 				mode: 'horizontal',
 				scaleID: 'y',
 				value: randomScalingFactor(),
 				borderColor: randomColor(0.75),
 				borderWidth: 5
-			});
+			};
 			window.myScatter.update();
 		}
 
 		function removeLine() {
-			window.myScatter.options.plugins.annotation.annotations.pop();
+			window.myScatter.options.plugins.annotation.annotations.myHorizontlLine = null;
 			window.myScatter.update();
 		}
 	</script>

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -142,11 +142,11 @@ function calculateElementProperties(chart, options, defaults) {
 		min = scaleValue(scale, options.value, NaN);
 		max = scaleValue(scale, options.endValue, min);
 		if (scale.isHorizontal()) {
-			x = Math.min(min, max);
-			x2 = Math.max(min, max);
+			x = min;
+			x2 = max;
 		} else {
-			y = Math.min(min, max);
-			y2 = Math.max(min, max);
+			y = min;
+			y2 = max;
 		}
 	} else {
 		const xScale = chart.scales[options.xScaleID];

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -27,8 +27,8 @@ export default {
 	beforeUpdate(chart, args, options) {
 		const annotationOptions = options || args;
 
-		const array = new Array();
-		if (!!annotationOptions.annotations) {
+		if (isObject(annotationOptions.annotations)) {
+			const array = new Array();
 			Object.keys(annotationOptions.annotations).forEach(key => {
 				let value = annotationOptions.annotations[key];
 				if (isObject(value)) {
@@ -36,8 +36,8 @@ export default {
 					array.push(value);
 				}
 			});
+			annotationOptions.annotations = array;
 		}
-		annotationOptions.annotations = array;
 
 		if (!args.mode) {
 			bindAfterDataLimits(chart, annotationOptions);

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -1,5 +1,5 @@
 import {Animations} from 'chart.js';
-import {clipArea, unclipArea, isFinite, merge, valueOrDefault, callback as callCallback} from 'chart.js/helpers';
+import {clipArea, unclipArea, isFinite, merge, valueOrDefault, callback as callCallback, isObject} from 'chart.js/helpers';
 import {handleEvent, updateListeners} from './events';
 import BoxAnnotation from './types/box';
 import LineAnnotation from './types/line';
@@ -26,6 +26,19 @@ export default {
 
 	beforeUpdate(chart, args, options) {
 		const annotationOptions = options || args;
+
+		const array = new Array();
+		if (!!annotationOptions.annotations) {
+			Object.keys(annotationOptions.annotations).forEach(key => {
+				let value = annotationOptions.annotations[key];
+				if (isObject(value)) {
+					value.id = key;
+					array.push(value);
+				}
+			});
+		}
+		annotationOptions.annotations = array;
+
 		if (!args.mode) {
 			bindAfterDataLimits(chart, annotationOptions);
 		}
@@ -62,7 +75,7 @@ export default {
 	defaults: {
 		drawTime: 'afterDatasetsDraw',
 		dblClickSpeed: 350, // ms
-		annotations: [],
+		annotations: {},
 		animation: {
 			numbers: {
 				properties: ['x', 'y', 'x2', 'y2', 'width', 'height'],


### PR DESCRIPTION
Fixes #247 and #249

The annotations node of setting is not longer an array  but now all annotations are managed as properties of an object where their key is their ID as well. 