### PR TITLE
Various fixes

### DIFF
--- a/src/annotation.js
+++ b/src/annotation.js
@@ -119,7 +119,7 @@ function updateElements(chart, state, options, mode) {
 		const properties = calculateElementProperties(chart, annotation, elType.defaults);
 		animations.update(el, properties);
 
-		const display = typeof annotation.display === 'function' ? callCallback(annotation.display, [{chart, element:el}], this) : valueOrDefault(annotation.display, true);
+		const display = typeof annotation.display === 'function' ? callCallback(annotation.display, [{chart, element: el}]) : valueOrDefault(annotation.display, true);
 		el._display = !!display;
 	}
 }

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -48,21 +48,21 @@ export default {
 		updateElements(chart, state, options, args.mode);
 	},
 
-	beforeDatasetsDraw(chart, options) {
+	beforeDatasetsDraw(chart, _args, options) {
 		draw(chart, options, 'beforeDatasetsDraw');
 	},
 
-	afterDatasetsDraw(chart, options) {
+	afterDatasetsDraw(chart, _args, options) {
 		draw(chart, options, 'afterDatasetsDraw');
 	},
 
-	afterDraw(chart, options) {
+	afterDraw(chart, _args, options) {
 		draw(chart, options, 'afterDraw');
 	},
 
-	beforeEvent(chart, event, _replay, options) {
+	beforeEvent(chart, args, options) {
 		const state = chartStates.get(chart);
-		handleEvent(chart, state, event, options);
+		handleEvent(chart, state, args.event, options);
 	},
 
 	destroy(chart) {

--- a/src/events.js
+++ b/src/events.js
@@ -7,6 +7,7 @@ const hooks = clickHooks.concat(moveHooks);
 export function updateListeners(chart, state, options) {
 	const annotations = options.annotations || [];
 	state.listened = false;
+	state.moveListened = false;
 
 	hooks.forEach(hook => {
 		if (typeof options[hook] === 'function') {


### PR DESCRIPTION
This fixes a few mistakes I found:

* Fix moveListened vs. listened: If a chart's only hooks were move hooks on individual annotations, then when the chart is updated, `state.listened` was cleared at the beginning of `updateListeners`, but since `state.moveListened` was still set, the `annotations.forEach` loop didn't re-evaluate move listeners and re-set `state.listened`.
* Update plugin hooks for the [new IPlugin interface](https://www.chartjs.org/docs/master/getting-started/v3-migration#iplugin-interface): This fixes problems with `handleEvent` not seeing the correct event type and with the drawTime option not being honored.
* Fix ESLint warnings: ESLint was giving a [no-invalid-this](https://eslint.org/docs/rules/no-invalid-this) warning. The annotations.display callback isn't documented as having a `this` parameter, and I don't see any way that `this` could work in this context, so I removed it.