### PR TITLE
Implement a separate labelDrawTime option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,6 @@ To configure the annotations plugin, you can simply add new config options to yo
                 // context: {chart, element}
             },
 
-            label: {
-                // Defines when annotations' labels are drawn.  Defaults to
-                // drawTime.
-                drawTime: 'afterDatasetsDraw', // (default)
-            },
-
             // Array of annotation configuration objects
             // or Object with the annotation configuration objects, one for each key
             // See below for detailed descriptions of the annotation options
@@ -92,9 +86,6 @@ Vertical or horizontal lines are supported.
     // optional drawTime to control layering, overrides global drawTime setting
     drawTime: 'afterDatasetsDraw',
 
-    // optional drawTime to control labels' layering; defaults to this element's drawTime
-    labelDrawTime: 'afterDatasetsDraw',
-
     // ID of the scale to bind onto
     scaleID: 'y',
 
@@ -121,6 +112,9 @@ Vertical or horizontal lines are supported.
     label: {
         // Background color of label, default below
         backgroundColor: 'rgba(0,0,0,0.8)',
+
+        // optional drawTime to control labels' layering; defaults to this element's drawTime
+        drawTime: 'afterDatasetsDraw',
 
         font: {
             // Font family of text, inherits from global

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ To configure the annotations plugin, you can simply add new config options to yo
             // See http://www.chartjs.org/docs/#advanced-usage-creating-plugins
             drawTime: 'afterDatasetsDraw', // (default)
 
+            // Defines when annotations' labels are drawn.  Defaults to
+            // drawTime.
+            labelDrawTime: 'afterDatasetsDraw', // (default)
+
             // Double-click speed in ms used to distinguish single-clicks from
             // double-clicks whenever you need to capture both. When listening for
             // both click and dblclick, click events will be delayed by this
@@ -41,7 +45,7 @@ To configure the annotations plugin, you can simply add new config options to yo
                 // context: {chart, element}
             },
 
-            // Array of annotation configuration objects 
+            // Array of annotation configuration objects
             // or Object with the annotation configuration objects, one for each key
             // See below for detailed descriptions of the annotation options
             annotations: [{
@@ -85,6 +89,9 @@ Vertical or horizontal lines are supported.
 
     // optional drawTime to control layering, overrides global drawTime setting
     drawTime: 'afterDatasetsDraw',
+
+    // optional drawTime to control labels' layering; defaults to this element's drawTime
+    labelDrawTime: 'afterDatasetsDraw',
 
     // ID of the scale to bind onto
     scaleID: 'y',
@@ -214,7 +221,7 @@ The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the bo
 
     // Fill color
     backgroundColor: 'green',
-    
+
     // Radius of box rectangle, default below
     cornerRadius: 0,
 
@@ -304,7 +311,7 @@ The 2 coordinates, xValue, yValue are optional. If not specified, the point is e
 
     // Stroke width
     borderWidth: 2,
-    
+
     // Radius of the point, default below
     radius: 10,
 
@@ -397,7 +404,7 @@ The 2 coordinates, xValue, yValue are optional. If not specified, the point is e
 
     // Stroke width
     borderWidth: 2,
-    
+
     // Radius of the point, default below
     radius: 10,
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ To configure the annotations plugin, you can simply add new config options to yo
             // See http://www.chartjs.org/docs/#advanced-usage-creating-plugins
             drawTime: 'afterDatasetsDraw', // (default)
 
-            // Defines when annotations' labels are drawn.  Defaults to
-            // drawTime.
-            labelDrawTime: 'afterDatasetsDraw', // (default)
-
             // Double-click speed in ms used to distinguish single-clicks from
             // double-clicks whenever you need to capture both. When listening for
             // both click and dblclick, click events will be delayed by this
@@ -43,6 +39,12 @@ To configure the annotations plugin, you can simply add new config options to yo
             // Fires when an annotation is hovered.
             enter: function(context) {
                 // context: {chart, element}
+            },
+
+            label: {
+                // Defines when annotations' labels are drawn.  Defaults to
+                // drawTime.
+                drawTime: 'afterDatasetsDraw', // (default)
             },
 
             // Array of annotation configuration objects

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -139,15 +139,19 @@ function resyncElements(elements, annotations) {
 
 function draw(chart, options, caller) {
 	const {ctx, chartArea} = chart;
-	const elements = chartStates.get(chart).elements;
+	const elements = chartStates.get(chart).elements.filter(el => el._display);
 
 	clipArea(ctx, chartArea);
-	for (let i = 0; i < elements.length; i++) {
-		const el = elements[i];
-		if (el._display && (el.options.drawTime || options.drawTime || caller) === caller) {
+	elements.forEach(el => {
+		if ((el.options.drawTime || options.drawTime || caller) === caller) {
 			el.draw(ctx);
 		}
-	}
+	});
+	elements.forEach(el => {
+		if ('drawLabel' in el && (el.options.labelDrawTime || el.options.drawTime || options.labelDrawTime || options.drawTime || caller) === caller) {
+			el.drawLabel(ctx);
+		}
+	});
 	unclipArea(ctx);
 }
 

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -148,7 +148,7 @@ function draw(chart, options, caller) {
 		}
 	});
 	elements.forEach(el => {
-		if ('drawLabel' in el && (el.options.labelDrawTime || el.options.drawTime || options.labelDrawTime || options.drawTime || caller) === caller) {
+		if ('drawLabel' in el && el.options.label && (el.options.label.drawTime || el.options.drawTime || options.drawTime || caller) === caller) {
 			el.drawLabel(ctx);
 		}
 	});

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -20,6 +20,7 @@ export function scaleValue(scale, value, fallback) {
  * @todo handle `radius` as top-left, top-right, bottom-right, bottom-left array/object?
  */
 export function roundedRect(ctx, x, y, width, height, radius) {
+	ctx.beginPath();
 	if (radius) {
 		const r = Math.min(radius, height / 2, width / 2);
 		const left = x + r;

--- a/src/types/box.js
+++ b/src/types/box.js
@@ -28,7 +28,6 @@ export default class BoxAnnotation extends Element {
 		ctx.strokeStyle = options.borderColor;
 		ctx.fillStyle = options.backgroundColor;
 
-		ctx.beginPath();
 		roundedRect(ctx, x, y, width, height, options.cornerRadius);
 		ctx.fill();
 		ctx.stroke();

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -157,7 +157,6 @@ function drawLabel(ctx, line) {
 	line.labelRect = {x: pos.x, y: pos.y, width, height};
 	loadCornersOfRotatedLabelRect(line.labelRect, rotation);
 
-	ctx.beginPath();
 	ctx.translate(pos.x, pos.y);
 	ctx.rotate(rotation);
 

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -66,11 +66,15 @@ export default class LineAnnotation extends Element {
 		ctx.lineTo(x2, y2);
 		ctx.stroke();
 
-		if (this.labelIsVisible()) {
-			drawLabel(ctx, this);
-		}
-
 		ctx.restore();
+	}
+
+	drawLabel(ctx) {
+		if (this.labelIsVisible()) {
+			ctx.save();
+			drawLabel(ctx, this);
+			ctx.restore();
+		}
 	}
 
 	resolveElementProperties(chart, options) {
@@ -153,6 +157,7 @@ function drawLabel(ctx, line) {
 	line.labelRect = {x: pos.x, y: pos.y, width, height};
 	loadCornersOfRotatedLabelRect(line.labelRect, rotation);
 
+	ctx.beginPath();
 	ctx.translate(pos.x, pos.y);
 	ctx.rotate(rotation);
 

--- a/types/label.d.ts
+++ b/types/label.d.ts
@@ -1,7 +1,9 @@
 import { Color, FontSpec } from "chart.js";
+import { DrawTime } from "./options";
 
 export interface LabelOptions {
 	backgroundColor?: Color,
+	drawTime?: DrawTime,
 	font?: FontSpec
 	/**
 	 * Padding of label to add left/right, default below


### PR DESCRIPTION
Implementation notes:

Since not all annotation types implement labels, the `drawLabel` method is optional.

If the `labelDrawTime` option isn't specified, then it checks the individual annotation's `drawTime` option, then the chart-wide annotation plugin's `labelDrawTime` option, then the chart-wide annotation plugin's `drawTime` option. This means that you can't override an individual annotation's `drawTime` without also affecting its `labelDrawTime`, but I think it's the more intuitive and backward-compatible behavior.

Since the option should default to `drawTime` if not set, I did not add it to the `defaults` object. Please let me know if I've misunderstood how plugins' default options should be implemented.