### PR TITLE
Auto register/unregister annotation types

### DIFF
--- a/src/annotation.js
+++ b/src/annotation.js
@@ -1,4 +1,4 @@
-import {Animations} from 'chart.js';
+import {Animations, Chart} from 'chart.js';
 import {clipArea, unclipArea, isFinite, merge, valueOrDefault, callback as callCallback, isObject} from 'chart.js/helpers';
 import {handleEvent, updateListeners} from './events';
 import BoxAnnotation from './types/box';
@@ -17,6 +17,14 @@ const annotationTypes = {
 
 export default {
   id: 'annotation',
+
+  afterRegister() {
+    Chart.register(annotationTypes);
+  },
+
+  afterUnregister() {
+    Chart.unregister(annotationTypes);
+  },
 
   beforeInit(chart) {
     chartStates.set(chart, {

--- a/src/index.esm.js
+++ b/src/index.esm.js
@@ -1,5 +1,1 @@
-export {default as Annotation} from './annotation';
-export {default as BoxAnnotation} from './types/box';
-export {default as LineAnnotation} from './types/line';
-export {default as EllipseAnnotation} from './types/ellipse';
-export {default as PointAnnotation} from './types/point';
+export {default} from './annotation';

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,6 @@
 import {Chart} from 'chart.js';
 import Annotation from './annotation';
-import BoxAnnotation from './types/box';
-import LineAnnotation from './types/line';
-import EllipseAnnotation from './types/ellipse';
-import PointAnnotation from './types/point';
 
-Chart.register(Annotation, BoxAnnotation, LineAnnotation, EllipseAnnotation, PointAnnotation);
+Chart.register(Annotation);
 
 export default Annotation;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,7 +9,7 @@ declare module 'chart.js' {
 
 declare const Annotation: Plugin;
 
-export { Annotation };
+export default Annotation;
 
 export * from './element';
 export * from './events';

--- a/types/test/exports.ts
+++ b/types/test/exports.ts
@@ -1,5 +1,5 @@
 import { Chart } from 'chart.js';
-import { Annotation } from '../index';
+import Annotation from '../index';
 
 Chart.register(Annotation);
 Chart.unregister(Annotation);

--- a/v3-migration.md
+++ b/v3-migration.md
@@ -8,9 +8,9 @@ chartjs-plugin-annotation 3.0 introduces a number of breaking changes.
 
 ```javascript
 import { Chart, LineController, LineElement, PointElement, LinearScale } from 'chart.js';
-import * as annotation from 'chartjs-plugin-annotation';
+import Annotation from 'chartjs-plugin-annotation';
 
-Chart.register(LineController, LineElement, PointElement, LinearScale, annotation);
+Chart.register(LineController, LineElement, PointElement, LinearScale, Annotation);
 
 const Chart = new Chart(ctx, {
     type: 'line',


### PR DESCRIPTION
Annotation types are not really designed to be shakeable, so it makes sense to automatically register them as elements when the plugin is registered.

This is one step towards removing the automatic registration from `UMD` build, for consistency.