### PR TITLE
Enables the callbacks for "values" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,17 +88,52 @@ To configure the annotations plugin, you can simply add new config options to yo
     scaleID: 'y',
 
     // Data value to draw the line at
+    // A callback can also be used:
+    //   value(context) {
+    //     // context: {chart, element}
+    //     return value;
+    //   },
     value: 25,
 
     // Optional value at which the line draw should end
+    // A callback can also be used:
+    //   endValue(context) {
+    //     // context: {chart, element}
+    //     return value;
+    //   },
     endValue: 26,
 
     // Alternative configuration of values, using two scales
     xScaleID: 'x',
     yScaleID: 'y',
+    
+    // Optional value for x point of starting line, in units along the x axis
+    // A callback can also be used:
+    //   xMin(context) {
+    //     // context: {chart, element}
+    //     return value;
+    //   },
     xMin: 'January',
+    // Optional value for y point of starting line, in units along the x axis
+    // A callback can also be used:
+    //   yMin(context) {
+    //     // context: {chart, element}
+    //     return value;
+    //   },
     yMin: 25,
+    // Optional value for x point of ending line, in units along the x axis
+    // A callback can also be used:
+    //   xMax(context) {
+    //     // context: {chart, element}
+    //     return value;
+    //   },
     xMax: 'February',
+    // Optional value for y point of ending line, in units along the x axis
+    // A callback can also be used:
+    //   yMax(context) {
+    //     // context: {chart, element}
+    //     return value;
+    //   },
     yMax: 26,
 
     // Line color
@@ -202,15 +237,35 @@ The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the bo
     yScaleID: 'y',
 
     // Left edge of the box. in units along the x axis
+    // A callback can also be used:
+    //   xMin(context) {
+    //     // context: {chart, element}
+    //     return value;
+    //   },
     xMin: 25,
 
     // Right edge of the box
+    // A callback can also be used:
+    //   xMax(context) {
+    //     // context: {chart, element}
+    //     return value;
+    //   },
     xMax: 40,
 
     // Top edge of the box in units along the y axis
+    // A callback can also be used:
+    //   yMax(context) {
+    //     // context: {chart, element}
+    //     return value;
+    //   },
     yMax: 20,
 
     // Bottom edge of the box
+    // A callback can also be used:
+    //   yMin(context) {
+    //     // context: {chart, element}
+    //     return value;
+    //   },
     yMin:  15,
 
     // Stroke color
@@ -253,15 +308,35 @@ The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the el
     yScaleID: 'y',
 
     // Left edge of the box. in units along the x axis
+    // A callback can also be used:
+    //   xMin(context) {
+    //     // context: {chart, element}
+    //     return value;
+    //   },
     xMin: 25,
 
     // Right edge of the box
+    // A callback can also be used:
+    //   xMax(context) {
+    //     // context: {chart, element}
+    //     return value;
+    //   },
     xMax: 40,
 
     // Top edge of the box in units along the y axis
+    // A callback can also be used:
+    //   yMax(context) {
+    //     // context: {chart, element}
+    //     return value;
+    //   },
     yMax: 20,
 
     // Bottom edge of the box
+    // A callback can also be used:
+    //   yMin(context) {
+    //     // context: {chart, element}
+    //     return value;
+    //   },
     yMin:  15,
 
     // Stroke color
@@ -301,9 +376,19 @@ The 2 coordinates, xValue, yValue are optional. If not specified, the point is e
     yScaleID: 'y',
 
     // Center point X value of the point. in units along the x axis
+    // A callback can also be used:
+    //   xValue(context) {
+    //     // context: {chart, element}
+    //     return value;
+    //   },
     xValue: 25,
 
     // Center point Y value of the point. in units along the y axis
+    // A callback can also be used:
+    //   yValue(context) {
+    //     // context: {chart, element}
+    //     return value;
+    //   },
     yValue: 20,
 
     // Stroke color

--- a/samples/labels.html
+++ b/samples/labels.html
@@ -137,7 +137,17 @@
 								myHorizontalLine: {
 									type: 'line',
 									scaleID: 'y',
-									value: 25,
+									value(context) {
+										let count = 0;
+										let sum = 0;
+										context.chart.data.datasets.forEach(function(dataset) {
+											dataset.data.forEach(function(data) {
+												count++;
+												sum += data.y;
+											});
+										});
+										return sum / count;
+									},
 									borderColor: 'black',
 									borderWidth: 5,
 									label: {

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -1,5 +1,6 @@
 import {Animations, Chart} from 'chart.js';
 import {clipArea, unclipArea, isFinite, merge, valueOrDefault, callback as callCallback, isObject} from 'chart.js/helpers';
+import {resolveValue} from './helpers';
 import {handleEvent, updateListeners} from './events';
 import BoxAnnotation from './types/box';
 import LineAnnotation from './types/line';
@@ -206,9 +207,9 @@ function getScaleLimits(scale, annotations) {
   let min = valueOrDefault(scale.min, Number.NEGATIVE_INFINITY);
   let max = valueOrDefault(scale.max, Number.POSITIVE_INFINITY);
   scaleAnnotations.forEach(annotation => {
-    ['value', 'endValue', axis + 'Min', axis + 'Max', 'xValue', 'yValue'].forEach(prop => {
+    ['value', 'endValue', axis + 'Min', axis + 'Max', axis + 'Value'].forEach(prop => {
       if (prop in annotation) {
-        const value = annotation[prop];
+        const value = resolveValue(scale.chart, annotation[prop]);
         min = Math.min(min, value);
         max = Math.max(max, value);
       }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,12 +1,18 @@
-import {isFinite} from 'chart.js/helpers';
+import {isFinite, callback as callCallback} from 'chart.js/helpers';
 
 const PI = Math.PI;
 const HALF_PI = PI / 2;
 
 export function scaleValue(scale, value, fallback) {
+  value = resolveValue(scale.chart, value);
   value = typeof value === 'string' ? scale.parse(value) : value;
   return isFinite(value) ? scale.getPixelForValue(value) : fallback;
 }
+
+export function resolveValue(chart, value) {
+  return typeof value === 'function' ? callCallback(value, [{chart}]) : value;
+}
+
 
 /**
  * Creates a "path" for a rectangle with rounded corners at position (x, y) with a

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -13,7 +13,6 @@ export function resolveValue(chart, value) {
   return typeof value === 'function' ? callCallback(value, [{chart}]) : value;
 }
 
-
 /**
  * Creates a "path" for a rectangle with rounded corners at position (x, y) with a
  * given size (width, height) and the same `radius` for all corners.

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -110,6 +110,7 @@ export default class LineAnnotation extends Element {
         y2 = scaleValue(yScale, options.yMax, y2);
       }
     }
+
     return {
       x,
       y,

--- a/test/specs/scriptableValues.spec.js
+++ b/test/specs/scriptableValues.spec.js
@@ -1,0 +1,68 @@
+describe('Scriptable values options', function() {
+
+  it('should not throw any exception', function() {
+    function createAndUpdateChart() {
+      const config = {
+        type: 'line',
+        data: {
+          labels: ['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange'],
+          datasets: [
+            {
+              label: '# of Votes',
+              data: [12, 19, 3, 5, 2, 3]
+            }
+          ]
+        },
+        options: {
+          scales: {
+            y: {
+              beginAtZero: true
+            }
+          },
+          plugins: {
+            annotation: {
+              drawTime: 'afterDatasetsDraw',
+              dblClickSpeed: 350,
+              annotations: {
+                my: {
+                  display: true,
+                  type: 'line',
+                  scaleID: 'y',
+                  value(context) {
+                    let count = 0;
+                    let sum = 0;
+                    context.chart.data.datasets.forEach(function(dataset) {
+                      dataset.data.forEach(function(data) {
+                        count++;
+                        sum += data;
+                      });
+                    });
+                    context.chart.annotationAverage = sum / count;
+                    return context.chart.annotationAverage;
+                  },
+                  borderColor: 'red',
+                  borderWidth: 2
+                }
+              }
+            }
+          }
+        }
+      };
+      var chart = acquireChart(config);
+      var count = 0;
+      var sum = 0;
+      var average = 0;
+      chart.data.datasets.forEach(function(dataset) {
+        dataset.data.forEach(function(data) {
+          count++;
+          sum += data;
+        });
+      });
+      average = sum / count;
+      if (chart.annotationAverage !== average) {
+        throw new Error('Average value ' + average + ' is not equals to average calculated by scriptable option ' + chart.annotationAverage);
+      }
+    }
+    expect(createAndUpdateChart).not.toThrow();
+  });
+});

--- a/test/specs/scriptableValues.spec.js
+++ b/test/specs/scriptableValues.spec.js
@@ -62,6 +62,12 @@ describe('Scriptable values options', function() {
       if (chart.annotationAverage !== average) {
         throw new Error('Average value ' + average + ' is not equals to average calculated by scriptable option ' + chart.annotationAverage);
       }
+      chart.annotationAverage = NaN;
+      chart.options.plugins.annotation.annotations.my.value = 10;
+      chart.update();
+      if (!isNaN(chart.annotationAverage)) {
+        throw new Error('Average value is not equals NaN');
+      }
     }
     expect(createAndUpdateChart).not.toThrow();
   });

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -8,8 +8,8 @@ export type Mode = 'horizontal' | 'vertical';
 export interface AnnotationTypeRegistry {
 	line: LineAnnotationOptions
 	box: BoxAnnotationOptions
-  ellipse: EllipseAnnotationOptions
-  point: PointAnnotationOptions
+	ellipse: EllipseAnnotationOptions
+	point: PointAnnotationOptions
 }
 
 export type AnnotationType = keyof AnnotationTypeRegistry;
@@ -19,23 +19,23 @@ export type AnnotationOptions<TYPE extends AnnotationType = AnnotationType> = De
 >;
 
 export interface CoreAnnotationOptions extends AnnotationEvents {
-  display?: boolean | ((context: EventContext) => boolean);
+	display?: boolean | ((context: EventContext) => boolean);
 	borderColor?: Color,
 	borderWidth?: number,
 	drawTime?: DrawTime,
-	endValue?: any,
+	endValue?: any | ((context: EventContext) => any);
 	mode?: Mode,
 	scaleID?: string,
-	value?: any,
+	value?: any | ((context: EventContext) => any);
 	xScaleID?: string,
 	yScaleID?: string,
 }
 
 interface AnnotationCoordinates {
-  xMax?: any,
-  xMin?: any,
-  yMax?: any,
-  yMin?: any,
+	xMax?: any | ((context: EventContext) => any);
+	xMin?: any | ((context: EventContext) => any);
+	yMax?: any | ((context: EventContext) => any);
+	yMin?: any | ((context: EventContext) => any);
 }
 
 export interface LineAnnotationOptions extends CoreAnnotationOptions, AnnotationCoordinates {
@@ -55,8 +55,8 @@ interface EllipseAnnotationOptions extends CoreAnnotationOptions, AnnotationCoor
 interface PointAnnotationOptions extends CoreAnnotationOptions {
 	backgroundColor: Color,
 	radius?: number,
-	xValue?: any;
-	yValue?: any;
+	xValue?: any | ((context: EventContext) => any);
+	yValue?: any | ((context: EventContext) => any);
 }
 
 export interface AnnotationPluginOptions extends AnnotationEvents {


### PR DESCRIPTION
Enables the user to configure the "values options" (`value`, `endValue`, `xMin`, `xMax`, `yMin`, `yMax`, `xValue`, `yValue`) in order to define the values of annotations at runtime.

Fixes #284