### PR TITLE
Moves color option out of font namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ To configure the annotations plugin, you can simply add new config options to yo
 
             // Font style of text, default below
             style: "bold",
-
-            // Font color of text, default below
-            color: "#fff",
         },
+
+        // Color of label text, default below
+        color: "#fff",
 
         // Padding of label to add left/right, default below
         xPadding: 6,

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -132,8 +132,8 @@ LineAnnotation.defaults = {
       family: defaults.font.family,
       size: defaults.font.size,
       style: 'bold',
-      color: '#fff',
     },
+    color: '#fff',
     xPadding: 6,
     yPadding: 6,
     rotation: 0,
@@ -170,7 +170,7 @@ function drawLabel(ctx, line, chartArea) {
   roundedRect(ctx, -(width / 2), -(height / 2), width, height, label.cornerRadius);
   ctx.fill();
 
-  ctx.fillStyle = label.font.color;
+  ctx.fillStyle = label.color;
   if (isArray(label.content)) {
     let textYPosition = -(height / 2) + label.yPadding;
     for (let i = 0; i < label.content.length; i++) {

--- a/types/label.d.ts
+++ b/types/label.d.ts
@@ -5,6 +5,7 @@ export interface LabelOptions {
 	backgroundColor?: Color,
 	drawTime?: DrawTime,
 	font?: FontSpec
+	color?: Color,
 	/**
 	 * Padding of label to add left/right
 	 * @default 6


### PR DESCRIPTION
Fixes #314

Moves `color` options out from `font` object in order to be aligned with Chart,js configuration.