### PR TITLE
Adjust scale range method using options instead of elements

### DIFF
--- a/src/annotation.js
+++ b/src/annotation.js
@@ -1,6 +1,5 @@
 import {Animations, Chart} from 'chart.js';
 import {clipArea, unclipArea, isFinite, merge, valueOrDefault, callback as callCallback, isObject} from 'chart.js/helpers';
-import {valueAsNumber} from './helpers';
 import {handleEvent, updateListeners} from './events';
 import BoxAnnotation from './types/box';
 import LineAnnotation from './types/line';
@@ -214,7 +213,7 @@ function getScaleLimits(scale, annotations) {
   scaleAnnotations.forEach(annotation => {
     ['value', 'endValue', axis + 'Min', axis + 'Max', 'xValue', 'yValue'].forEach(prop => {
       if (prop in annotation) {
-        const value = valueAsNumber(scale, annotation[prop]);
+        const value = scale.parse(annotation[prop]);
         min = Math.min(min, value);
         max = Math.max(max, value);
       }

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -38,7 +38,7 @@ export default {
   },
 
   afterDataLimits(chart, args, options) {
-    if (scale.type !== 'category') {
+    if (args.scale.type !== 'category') {
       adjustScaleRange(chart, args.scale, options);
     }
   },

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -1,5 +1,6 @@
 import {Animations, Chart} from 'chart.js';
 import {clipArea, unclipArea, isFinite, merge, valueOrDefault, callback as callCallback, isObject} from 'chart.js/helpers';
+import {valueAsNumber} from './helpers';
 import {handleEvent, updateListeners} from './events';
 import BoxAnnotation from './types/box';
 import LineAnnotation from './types/line';
@@ -37,8 +38,9 @@ export default {
   },
 
   afterDataLimits(chart, args, options) {
-    const state = chartStates.get(chart);
-    adjustScaleRange(args.scale, state, options);
+    if (scale.type !== 'category') {
+      adjustScaleRange(chart, args.scale, options);
+    }
   },
 
   beforeUpdate(chart, args, options) {
@@ -114,6 +116,11 @@ function resolveAnimations(chart, animOpts, mode) {
   return new Animations(chart, animOpts);
 }
 
+function isAnnotationVisible(chart, options, element) {
+  const display = typeof options.display === 'function' ? callCallback(options.display, [{chart, element}]) : valueOrDefault(options.display, true);
+  return !!display;
+}
+
 function updateElements(chart, state, options, mode) {
   const chartAnims = chart.options.animation;
   const animOpts = chartAnims && merge({}, [chartAnims, options.animation]);
@@ -133,8 +140,7 @@ function updateElements(chart, state, options, mode) {
     properties.options = merge(Object.create(null), [elType.defaults, annotation]);
     animations.update(el, properties);
 
-    const display = typeof annotation.display === 'function' ? callCallback(annotation.display, [{chart, element: el}]) : valueOrDefault(annotation.display, true);
-    el._display = !!display;
+    el._display = isAnnotationVisible(chart, annotation, el);
   }
 }
 
@@ -170,15 +176,15 @@ function draw(chart, options, caller) {
   });
 }
 
-function getAnnotationOptions(elements, options) {
-  if (elements && elements.length) {
-    return elements.filter(el => el._display).map(el => el.options);
+function getAnnotationOptions(chart, options) {
+  if (options.annotations && options.annotations.length) {
+    return options.annotations.filter(annotation => isAnnotationVisible(chart, annotation));
   }
-  return options.annotations || [];
+  return [];
 }
 
-function adjustScaleRange(scale, state, options) {
-  const annotations = getAnnotationOptions(state.elements, options);
+function adjustScaleRange(chart, scale, options) {
+  const annotations = getAnnotationOptions(chart, options);
   const range = getScaleLimits(scale, annotations);
   let changed = false;
   if (isFinite(range.min) &&
@@ -208,7 +214,7 @@ function getScaleLimits(scale, annotations) {
   scaleAnnotations.forEach(annotation => {
     ['value', 'endValue', axis + 'Min', axis + 'Max', 'xValue', 'yValue'].forEach(prop => {
       if (prop in annotation) {
-        const value = annotation[prop];
+        const value = valueAsNumber(scale, annotation[prop]);
         min = Math.min(min, value);
         max = Math.max(max, value);
       }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -4,8 +4,12 @@ const PI = Math.PI;
 const HALF_PI = PI / 2;
 
 export function scaleValue(scale, value, fallback) {
-  value = typeof value === 'string' ? scale.parse(value) : value;
+  value = valueAsNumber(scale, value);
   return isFinite(value) ? scale.getPixelForValue(value) : fallback;
+}
+
+export function valueAsNumber(scale, value) {
+  return typeof value === 'string' ? scale.parse(value) : value instanceof Date ? value.getTime() : value;
 }
 
 /**

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -4,12 +4,8 @@ const PI = Math.PI;
 const HALF_PI = PI / 2;
 
 export function scaleValue(scale, value, fallback) {
-  value = valueAsNumber(scale, value);
+  value = typeof value === 'number' ? value : scale.parse(value);
   return isFinite(value) ? scale.getPixelForValue(value) : fallback;
-}
-
-export function valueAsNumber(scale, value) {
-  return typeof value === 'string' ? scale.parse(value) : value instanceof Date ? value.getTime() : value;
 }
 
 /**


### PR DESCRIPTION
The `adjustScaleRange` method, which is calculating and adjusting the min and max values of a scale based on values of annotations, is evaluating the annotations values taking the options from elements in the state.
Elements are created/updated after the `adjustScaleRange` method therefore the method should not use elements. In this PR the method is using the options. 

Setting the min and max values for a category scale doesn't make sense because the value of annotation should be in the configured labels of the chart.