### PR TITLE
Fix configuration instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ To configure the annotations plugin, you can simply add new config options to yo
         },
 
         // Color of label text, default is '#fff'.
-        color: '#fff',
+        fontColor: '#fff',
 
         // Padding of label to add left/right, default is 6.
         xPadding: 6,


### PR DESCRIPTION
The `color` option no longer seems to work since the latest versions. I believe the configuration instructions in the README should have this changed to `fontColor`.