### PR TITLE
Resolve element options to concrete values

### DIFF
--- a/src/types/line.js
+++ b/src/types/line.js
@@ -127,6 +127,7 @@ LineAnnotation.defaults = {
   borderDashOffset: 0,
   label: {
     backgroundColor: 'rgba(0,0,0,0.8)',
+    drawTime: undefined,
     font: {
       family: undefined,
       lineHeight: undefined,

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -128,7 +128,11 @@ LineAnnotation.defaults = {
   label: {
     backgroundColor: 'rgba(0,0,0,0.8)',
     font: {
+      family: undefined,
+      lineHeight: undefined,
+      size: undefined,
       style: 'bold',
+      weight: undefined
     },
     color: '#fff',
     xPadding: 6,


### PR DESCRIPTION
Results to this:
![image](https://user-images.githubusercontent.com/27971921/112362383-0a18f180-8cdd-11eb-9a74-c48cf1e46861.png)

Instead of this:
![image](https://user-images.githubusercontent.com/27971921/112362519-32085500-8cdd-11eb-80c0-5fa46e4b24cb.png)

And prevents this:
![image](https://user-images.githubusercontent.com/27971921/112362636-52381400-8cdd-11eb-9f05-14f04bcc0e2a.png)

Reproduce of the above error, hit randomize data couple of times there (and inspect console):
https://www.chartjs.org/chartjs-plugin-annotation/samples/types/line.html
