### PR TITLE
Type fixes

### DIFF
--- a/docs/guide/options.md
+++ b/docs/guide/options.md
@@ -11,7 +11,7 @@ Fonts use the same format as [chart.js](https://www.chartjs.org/docs/master/gene
 ## Scriptable Options
 
 As with most options in chart.js, the annotation plugin options are scriptable. This means that a function can be passed which returns the value as needed. In the example below, the annotation is hidden when the screen is less than 1000px wide.
-The function receives 2 arguments, first is the [option context](#option-context) representing contextual information. An options resolver is passed as second argument, which can be used to access other option in the same context.
+The function receives 2 arguments, first is the [option context](#option-context) representing contextual information. An options object is passed as second argument, containing the options that were originally passed in to configure the annotation element.
 
 ```js chart-editor
 /* <block:options:0> */
@@ -22,7 +22,7 @@ const options = {
       annotations: {
         box1: {
           drawTime: 'afterDatasetsDraw',
-          display: (context) => {
+          display: (context, options) => {
             const body = document.querySelector('body');
             const rect = body.getBoundingClientRect();
             return rect.width >= 1000;
@@ -100,3 +100,5 @@ In addition to [chart](#chart)
 * `type`: `'annotation'`
 
 The [annotation](#annotation) option context is passed to scriptable options in all other cases, except when resolving `id`, `type` or adjusting scale ranges. The same values resolved in `afterDataLimits` with [chart](#chart) context are again evaluated in `afterUpdate` with [annotation](#annotation) context.
+
+Note that the annotation element may be undefined or partially uninitialized, since scriptable options may be invoked during the initial chart display, before everything's been resolved and initialized.

--- a/docs/guide/options.md
+++ b/docs/guide/options.md
@@ -11,7 +11,7 @@ Fonts use the same format as [chart.js](https://www.chartjs.org/docs/master/gene
 ## Scriptable Options
 
 As with most options in chart.js, the annotation plugin options are scriptable. This means that a function can be passed which returns the value as needed. In the example below, the annotation is hidden when the screen is less than 1000px wide.
-The function receives 2 arguments, first is the [option context](#option-context) representing contextual information. An options resolver is passed as second argumet, which can be used to access other option in the same context.
+The function receives 2 arguments, first is the [option context](#option-context) representing contextual information. An options resolver is passed as second argument, which can be used to access other option in the same context.
 
 ```js chart-editor
 /* <block:options:0> */

--- a/docs/guide/options.md
+++ b/docs/guide/options.md
@@ -11,7 +11,7 @@ Fonts use the same format as [chart.js](https://www.chartjs.org/docs/master/gene
 ## Scriptable Options
 
 As with most options in chart.js, the annotation plugin options are scriptable. This means that a function can be passed which returns the value as needed. In the example below, the annotation is hidden when the screen is less than 1000px wide.
-The function receives 2 arguments, first is the [option context](#option-context) representing contextual information. An options object is passed as second argument, containing the options that were originally passed in to configure the annotation element.
+The function receives 2 arguments, first is the [option context](#option-context) representing contextual information. An options resolver is passed as second argument, which can be used to access the options that were originally passed in to configure the annotation element.
 
 ```js chart-editor
 /* <block:options:0> */

--- a/types/events.d.ts
+++ b/types/events.d.ts
@@ -6,6 +6,15 @@ export interface EventContext {
 	element: AnnotationElement
 }
 
+/**
+ * Some scriptable options may be called with during the chart's initial
+ * display, when the element isn't fully initialized.
+ */
+export interface PartialEventContext {
+  chart: Chart,
+  element?: Partial<AnnotationElement>,
+}
+
 export interface AnnotationEvents {
 	enter?(context: EventContext): void,
 	leave?(context: EventContext): void,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,6 +2,7 @@ import { Plugin, ChartType } from 'chart.js';
 import { AnnotationPluginOptions } from './options';
 
 declare module 'chart.js' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface PluginOptionsByType<TType extends ChartType> {
     annotation: AnnotationPluginOptions;
   }

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1,5 +1,5 @@
 import { Color } from 'chart.js';
-import { AnnotationEvents, EventContext } from './events';
+import { AnnotationEvents, PartialEventContext } from './events';
 import { LabelOptions } from './label';
 
 export type DrawTime = 'afterDraw' | 'afterDatasetsDraw' | 'beforeDraw' | 'beforeDatasetsDraw';
@@ -19,7 +19,7 @@ export type AnnotationOptions<TYPE extends AnnotationType = AnnotationType> =
 
 export interface CoreAnnotationOptions extends AnnotationEvents {
 	id?: string,
-	display?: boolean | ((context: EventContext) => boolean),
+	display?: boolean | ((context: PartialEventContext, options: AnnotationOptions) => boolean),
 	borderColor?: Color,
 	borderWidth?: number,
 	borderDash?: [number, number],

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -18,7 +18,8 @@ export type AnnotationOptions<TYPE extends AnnotationType = AnnotationType> =
 
 
 export interface CoreAnnotationOptions extends AnnotationEvents {
-  display?: boolean | ((context: EventContext) => boolean);
+	id?: string,
+	display?: boolean | ((context: EventContext) => boolean),
 	borderColor?: Color,
 	borderWidth?: number,
 	borderDash?: [number, number],
@@ -59,7 +60,7 @@ interface PointAnnotationOptions extends CoreAnnotationOptions {
 }
 
 export interface AnnotationPluginOptions extends AnnotationEvents {
-	annotations: AnnotationOptions[]
+	annotations: AnnotationOptions[] | Record<string, AnnotationOptions>,
 	dblClickSpeed?: number,
 	drawTime?: DrawTime,
 }


### PR DESCRIPTION
Allow `annotations` to be an object (as used in the current documentation) as well as an array (as used by older versions of the plugin).

Allow `id` property, as set by the object form of `annotations`.

Suppress ESLint warning; TypeScript declaration merging must exactly match the original, so ESLint's warning that the type is unused is a false positive.

Fix a typo in options.md.