### PR TITLE
Update vuepress-theme-chartjs

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  dest: 'dist/docs',
   title: 'chartjs-plugin-annotation',
   description: 'Annotations for Chart.js',
   theme: 'chartjs',

--- a/package-lock.json
+++ b/package-lock.json
@@ -12901,9 +12901,9 @@
       }
     },
     "rollup": {
-      "version": "2.43.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.43.0.tgz",
-      "integrity": "sha512-FRsYGqlo1iF/w3bv319iStAK0hyhhwon35Cbo7sGUoXaOpsZFy6Lel7UoGb5bNDE4OsoWjMH94WiVvpOM26l3g==",
+      "version": "2.43.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.43.1.tgz",
+      "integrity": "sha512-kvRE6VJbiv4d8m2nGeccc3qRpzOMghAhu2KeITjyZVCjneIFLPQ3zm2Wmqnl0LcUg3FvDaV0MfKnG4NCMbiSfw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.1"
@@ -15233,9 +15233,9 @@
       }
     },
     "vuepress-theme-chartjs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/vuepress-theme-chartjs/-/vuepress-theme-chartjs-0.1.0.tgz",
-      "integrity": "sha512-xOmMXTRk2z8jw/Qfl95iRwzIqkW5JWa0oUZ9EqgSseRcLmVgfrk6Wf1MaWSXY3ZwGBGMOCV5GQeaL+VtyEF+jQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/vuepress-theme-chartjs/-/vuepress-theme-chartjs-0.2.0.tgz",
+      "integrity": "sha512-OE9fdPN/bV+SM6dGIjM4nUSEzvHHbQlIriJi4bdVvlSDufgXkkfUbbu+aDqx/a7n7wrqWaTQox73KZX5FFY7rw==",
       "dev": true,
       "requires": {
         "acorn": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "karma start --auto-watch --no-single-run --browsers chrome",
-    "docs": "npm run build && vuepress build docs --dest dist/docs",
-    "docs:dev": "npm run build && vuepress dev docs",
+    "docs": "npm run build && vuepress build docs --no-cache",
+    "docs:dev": "npm run build && vuepress dev docs --no-cache",
     "lint": "concurrently \"npm:lint-*\"",
     "lint-js": "eslint \"old_samples/**/*.html\" \"test/**/*.js\" \"src/**/*.js\"",
     "lint-md": "markdownlint-cli2 \"**/*.md\" \"**/*.mdx\" \"#**/node_modules\"",
@@ -52,16 +52,16 @@
     "karma-rollup-preprocessor": "^7.0.7",
     "markdownlint-cli2": "0.0.15",
     "pixelmatch": "^5.2.1",
-    "rollup": "^2.43.0",
+    "rollup": "^2.43.1",
     "rollup-plugin-istanbul": "^3.0.0",
     "rollup-plugin-terser": "^7.0.2",
     "typescript": "^4.2.3",
     "vuepress": "^1.8.2",
     "vuepress-plugin-redirect": "^1.2.5",
-    "vuepress-theme-chartjs": "^0.1.0"
+    "vuepress-theme-chartjs": "^0.2.0"
   },
   "peerDependencies": {
-    "chart.js": "^3.0.0-rc.3"
+    "chart.js": "^3.0.0-rc.6"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
The chart editor does not work properly in vuepress-theme-chartjs 0.1.0. It was fixed in 0.2.0