### PR TITLE
Enables textAlign option to line label

### DIFF
--- a/docs/guide/types/line.md
+++ b/docs/guide/types/line.md
@@ -125,6 +125,7 @@ All of these options can be [Scriptable](../options#scriptable-options)
 | `xAdjust` | `number` | `0` | Adjustment along x-axis (left-right) of label relative to computed position. Negative values move the label left, positive right.
 | `yAdjust` | `number` | `0` | Adjustment along y-axis (top-bottom) of label relative to computed position. Negative values move the label up, positive down.
 | `position` | `string` | `'center'` | Anchor position of label on line. Possible options are: `'start'`, `'center'`, `'end'`.
+| `textAlign` | `string` | `'center'` | Text alignment of label content when there's more than one line. Possible options are: `'start'`, `'center'`, `'end'`.
 | `width` | `number`\|`string` | `undefined` | Overrides the width of the image. Could be set in pixel by a number, or in percentage of current width of image by a string. If undefined, uses the width of the image. It is used only when the content is an image.
 | `height` | `number`\|`string` | `undefined` | Overrides the height of the image. Could be set in pixel by a number, or in percentage of current height of image by a string. If undefined, uses the height of the image. It is used only when the content is an image.
 | `rotation` | `number`\|`'auto'` | `0` | Rotation of label, in degrees, or 'auto' to use the degrees of the line

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -143,6 +143,7 @@ LineAnnotation.defaults = {
     position: 'center',
     xAdjust: 0,
     yAdjust: 0,
+    textAlign: 'center',
     enabled: false,
     content: null
   },
@@ -172,7 +173,6 @@ function drawLabel(ctx, line, chartArea) {
   const label = line.options.label;
 
   ctx.font = toFontString(label.font);
-  ctx.textAlign = 'center';
 
   const {width, height} = measureLabel(ctx, label);
   const rect = line.labelRect = calculateLabelPosition(line, width, height, chartArea);
@@ -186,12 +186,14 @@ function drawLabel(ctx, line, chartArea) {
 
   ctx.fillStyle = label.color;
   if (isArray(label.content)) {
+    ctx.textAlign = label.textAlign;
+    const x = calculateLabelXAlignment(label, width);
     let textYPosition = -(height / 2) + label.yPadding;
     for (let i = 0; i < label.content.length; i++) {
       ctx.textBaseline = 'top';
       ctx.fillText(
         label.content[i],
-        -(width / 2) + (width / 2),
+        x,
         textYPosition
       );
       textYPosition += label.font.size + label.yPadding;
@@ -201,9 +203,20 @@ function drawLabel(ctx, line, chartArea) {
     const y = -(height / 2) + label.yPadding;
     ctx.drawImage(label.content, x, y, width - (2 * label.xPadding), height - (2 * label.yPadding));
   } else {
+    ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillText(label.content, 0, 0);
   }
+}
+
+function calculateLabelXAlignment(label, width) {
+  const {textAlign, xPadding} = label;
+  if (textAlign === 'start') {
+    return -(width / 2) + xPadding;
+  } else if (textAlign === 'end') {
+    return +(width / 2) - xPadding;
+  }
+  return 0;
 }
 
 function getImageSize(size, value) {

--- a/types/label.d.ts
+++ b/types/label.d.ts
@@ -29,6 +29,12 @@ export interface LabelOptions {
 	position?: LabelPosition,
 
 	/**
+	 * Text alignment when the content of the label is multi-line.
+	 * @default 'center'
+	 */
+	textAlign?: LabelTextAlign,
+
+	/**
 	 * Adjustment along x-axis (left-right) of label relative to above number (can be negative)
 	 * For horizontal lines positioned left or right, negative values move
 	 * the label toward the edge, and positive values toward the center.
@@ -75,3 +81,5 @@ export interface LabelOptions {
 }
 
 export type LabelPosition = 'top' | 'bottom' | 'left' | 'right' | 'center';
+
+export type LabelTextAlign = 'start' | 'center' | 'end';


### PR DESCRIPTION
PR implements `textAlign` option for line label in order to justify label content when there's more than one line.

Fixes #189
