### PR TITLE
Update LabelPosition type to match v1.0.0

### DIFF
--- a/types/label.d.ts
+++ b/types/label.d.ts
@@ -81,6 +81,6 @@ export interface LabelOptions {
 	rotation?: Scriptable<number | 'auto', PartialEventContext>
 }
 
-export type LabelPosition = 'top' | 'bottom' | 'left' | 'right' | 'center';
+export type LabelPosition = 'start' | 'center' | 'end';
 
 export type LabelTextAlign = 'start' | 'center' | 'end';


### PR DESCRIPTION
The type definitions still used v0.x's `'top' | 'bottom' | 'left' | 'right' | 'center'`.

I noticed that LabelPosition is now identical to LabelTextAlign; however, they seem logically different, so keeping separate types made sense.