### PR TITLE
Fixes for line mouse events

### DIFF
--- a/src/types/line.js
+++ b/src/types/line.js
@@ -4,10 +4,7 @@ import {scaleValue, roundedRect, rotated} from '../helpers';
 
 const PI = Math.PI;
 const clamp = (x, from, to) => Math.min(to, Math.max(from, x));
-const pointInLine = (p1, p2, t) => {
-  t = clamp(t, 0, 1);
-  return {x: p1.x + t * (p2.x - p1.x), y: p1.y + t * (p2.y - p1.y)};
-};
+const pointInLine = (p1, p2, t) => ({x: p1.x + t * (p2.x - p1.x), y: p1.y + t * (p2.y - p1.y)});
 const interpolateX = (y, p1, p2) => pointInLine(p1, p2, Math.abs((y - p1.y) / (p2.y - p1.y))).x;
 const interpolateY = (x, p1, p2) => pointInLine(p1, p2, Math.abs((x - p1.x) / (p2.x - p1.x))).y;
 const toPercent = (s) => typeof s === 'string' && s.endsWith('%') && parseFloat(s) / 100;


### PR DESCRIPTION
I found a couple of issues with the mouse event handling:

First, the isOnLabel logic didn't check whether the label was currently shown, so if a label had ever been draw in the past, its rectangle would continue to count for determining whether the mouse was on the line annotation.

Second, the logic I added for restricting mouse events to where the line actually is (#403) didn't work for horizontal or vertical lines.  For those, the denominator in interpolateY / interpolateX was 0, so the resulting value was infinity, which was clamped to 1; effectively, only the endpoint of the line could trigger a mouse enter event.