### PR TITLE
Add missing animations prop to options interface.

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -65,5 +65,6 @@ interface PointAnnotationOptions extends CoreAnnotationOptions {
 export interface AnnotationPluginOptions extends AnnotationEvents {
 	annotations: AnnotationOptions[] | Record<string, AnnotationOptions>,
 	dblClickSpeed?: Scriptable<number, PartialEventContext>,
-	drawTime?: Scriptable<DrawTime, PartialEventContext>,
+  drawTime?: Scriptable<DrawTime, PartialEventContext>,
+  animations: Record<string, unknown>,
 }


### PR DESCRIPTION
Hi, I can see `options.animations` being passed to `new Animations(chart, animOpts)` object here:
https://github.com/chartjs/chartjs-plugin-annotation/blob/v1.0.2/src/annotation.js#L140
(and I am actually using that option)

Animation:
https://github.com/chartjs/Chart.js/blob/a8337a3/types/animation.d.ts#L29

AnyObject:
https://github.com/chartjs/Chart.js/blob/a8337a32c976393e4648de633dcc49cdec2760b3/types/basic.d.ts#L2