### PR TITLE
Add borderCapStyle and borderJoinStyle options to BoxAnnotation

### DIFF
--- a/docs/guide/types/box.md
+++ b/docs/guide/types/box.md
@@ -60,12 +60,14 @@ The following options are available for box annotations.
 | [`xMax`](#general) | `number` \| `string` | Yes | `undefined`
 | [`yMin`](#general) | `number` \| `string` | Yes | `undefined`
 | [`yMax`](#general) | `number` \| `string` | Yes | `undefined`
-| [`borderColor`](#styling) | [`Color`](../options#color) | Yes | `options.color`
-| [`borderWidth`](#styling) | `number`| Yes | `1`
-| [`borderDash`](#styling) | `number[]`| Yes | `[]`
-| [`borderDashOffset`](#styling) | `number`| Yes | `0`
 | [`backgroundColor`](#styling) | [`Color`](../options#color) | Yes | `options.color`
+| [`borderCapStyle`](#styling) | `string` | Yes | `'butt'`
+| [`borderColor`](#styling) | [`Color`](../options#color) | Yes | `options.color`
+| [`borderDash`](#styling) | `number[]` | Yes | `[]`
+| [`borderDashOffset`](#styling) | `number` | Yes | `0`
+| [`borderJoinStyle`](#styling) | `string` | Yes | `'miter'`
 | [`borderRadius`](#styling) | `number` \| `object` | Yes | `0`
+| [`borderWidth`](#styling) | `number`| Yes | `1`
 
 ### General
 
@@ -87,12 +89,14 @@ If one of the axes does not match an axis in the chart, the box will take the en
 
 | Name | Description |
 | ---- | ---- |
-| `borderColor` | Stroke color
-| `borderWidth` | Stroke width
+| `backgroundColor` | Fill color.
+| `borderColor` | Stroke color.
+| `borderCapStyle` | Cap style of the border line. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap).
 | `borderDash` | Length and spacing of dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash).
-| `borderDashOffset` | Offset for line dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset).
-| `backgroundColor` | Fill color
-| [`borderRadius`](#borderRadius) | Radius of box rectangle (in pixels)
+| `borderDashOffset` | Offset for border line dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset).
+| `borderJoinStyle` | Border line joint style. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineJoin).
+| [`borderRadius`](#borderradius) | Radius of box rectangle (in pixels)
+| `borderWidth` | Border line width (in pixels).
 
 #### borderRadius
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -32,3 +32,21 @@ export function rotated(point, center, angle) {
     y: cy + sin * (point.x - cx) + cos * (point.y - cy)
   };
 }
+
+/**
+ * Apply border options to the canvas context before drawing a box
+ * @param {CanvasRenderingContext2D} ctx - chart canvas context
+ * @param {Object} options - options with border configuration
+ * @returns {boolean} true is the border options have been applied
+ */
+export function setBorderStyle(ctx, options) {
+  if (ctx && options && options.borderWidth) {
+    ctx.lineCap = options.borderCapStyle;
+    ctx.setLineDash(options.borderDash);
+    ctx.lineDashOffset = options.borderDashOffset;
+    ctx.lineJoin = options.borderJoinStyle;
+    ctx.lineWidth = options.borderWidth;
+    ctx.strokeStyle = options.borderColor;
+    return true;
+  }
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -40,7 +40,7 @@ export function rotated(point, center, angle) {
  * @returns {boolean} true is the border options have been applied
  */
 export function setBorderStyle(ctx, options) {
-  if (ctx && options && options.borderWidth) {
+  if (options && options.borderWidth) {
     ctx.lineCap = options.borderCapStyle;
     ctx.setLineDash(options.borderDash);
     ctx.lineDashOffset = options.borderDashOffset;

--- a/src/types/box.js
+++ b/src/types/box.js
@@ -1,6 +1,6 @@
 import {Element} from 'chart.js';
 import {addRoundedRectPath, toTRBLCorners, valueOrDefault} from 'chart.js/helpers';
-import {clampAll, scaleValue} from '../helpers';
+import {clampAll, scaleValue, setBorderStyle} from '../helpers';
 
 export default class BoxAnnotation extends Element {
   inRange(mouseX, mouseY, useFinalPosition) {
@@ -28,9 +28,7 @@ export default class BoxAnnotation extends Element {
     ctx.lineWidth = options.borderWidth;
     ctx.strokeStyle = options.borderColor;
     ctx.fillStyle = options.backgroundColor;
-
-    ctx.setLineDash(options.borderDash);
-    ctx.lineDashOffset = options.borderDashOffset;
+    const stroke = setBorderStyle(ctx, options);
 
     ctx.beginPath();
     addRoundedRectPath(ctx, {
@@ -40,12 +38,10 @@ export default class BoxAnnotation extends Element {
     });
     ctx.closePath();
     ctx.fill();
-
     // If no border, don't draw it
-    if (options.borderWidth) {
+    if (stroke) {
       ctx.stroke();
     }
-
     ctx.restore();
   }
 
@@ -89,10 +85,12 @@ BoxAnnotation.id = 'boxAnnotation';
 BoxAnnotation.defaults = {
   display: true,
   adjustScaleRange: true,
+  borderCapStyle: 'butt',
   borderDash: [],
   borderDashOffset: 0,
-  borderWidth: 1,
+  borderJoinStyle: 'miter',
   borderRadius: 0,
+  borderWidth: 1,
   xScaleID: 'x',
   xMin: undefined,
   xMax: undefined,

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -1,6 +1,6 @@
 import {Element} from 'chart.js';
 import {addRoundedRectPath, isArray, toFont, toRadians, toTRBLCorners, valueOrDefault} from 'chart.js/helpers';
-import {clamp, clampAll, scaleValue, rotated} from '../helpers';
+import {clamp, clampAll, scaleValue, rotated, setBorderStyle} from '../helpers';
 
 const PI = Math.PI;
 const pointInLine = (p1, p2, t) => ({x: p1.x + t * (p2.x - p1.x), y: p1.y + t * (p2.y - p1.y)});
@@ -258,18 +258,6 @@ function drawLabel(ctx, line, chartArea) {
     ctx.textBaseline = 'middle';
     ctx.textAlign = label.textAlign;
     labels.forEach((l, i) => ctx.fillText(l, x, y + (i * font.lineHeight)));
-  }
-}
-
-function setBorderStyle(ctx, options) {
-  if (options.borderWidth) {
-    ctx.lineCap = options.borderCapStyle;
-    ctx.setLineDash(options.borderDash);
-    ctx.lineDashOffset = options.borderDashOffset;
-    ctx.lineJoin = options.borderJoinStyle;
-    ctx.lineWidth = options.borderWidth;
-    ctx.strokeStyle = options.borderColor;
-    return true;
   }
 }
 

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -48,6 +48,26 @@ export interface LineAnnotationOptions extends CoreAnnotationOptions, Annotation
 
 export interface BoxAnnotationOptions extends CoreAnnotationOptions, AnnotationCoordinates {
   backgroundColor?: Scriptable<Color, PartialEventContext>,
+  /**
+   * Border line cap style. See MDN.
+   * @default 'butt'
+   */
+  borderCapStyle?: Scriptable<CanvasLineCap, PartialEventContext>,
+  /**
+   * Border line dash. See MDN.
+   * @default []
+   */
+  borderDash?: Scriptable<number[], PartialEventContext>,
+  /**
+   * Border line dash offset. See MDN.
+   * @default 0.0
+   */
+  borderDashOffset?: Scriptable<number, PartialEventContext>,
+  /**
+   * Border line join style. See MDN.
+   * @default 'miter'
+   */
+  borderJoinStyle?: Scriptable<CanvasLineJoin, PartialEventContext>,
   borderRadius?: Scriptable<number, PartialEventContext>,
   /**
    * @deprecated replaced by borderRadius


### PR DESCRIPTION
- Add borderCapStyle and borderJoinStyle options to BoxAnnotation
- Move setBorderStyle function to the helpers, from line annotation, in order to be used by both BoxAnnotation and LineAnnotation label