### PR TITLE
Move annotation types handling to types/index.js

### DIFF
--- a/src/annotation.js
+++ b/src/annotation.js
@@ -1,30 +1,10 @@
-import {Animations, Chart, defaults} from 'chart.js';
+import {Animations, Chart} from 'chart.js';
 import {clipArea, unclipArea, isFinite, valueOrDefault, isObject, isArray} from 'chart.js/helpers';
 import {handleEvent, hooks, updateListeners} from './events';
-import BoxAnnotation from './types/box';
-import LineAnnotation from './types/line';
-import EllipseAnnotation from './types/ellipse';
-import LabelAnnotation from './types/label';
-import PointAnnotation from './types/point';
-import PolygonAnnotation from './types/polygon';
+import {annotationTypes} from './types';
 import {version} from '../package.json';
 
 const chartStates = new Map();
-
-const annotationTypes = {
-  box: BoxAnnotation,
-  ellipse: EllipseAnnotation,
-  label: LabelAnnotation,
-  line: LineAnnotation,
-  point: PointAnnotation,
-  polygon: PolygonAnnotation
-};
-
-Object.keys(annotationTypes).forEach(key => {
-  defaults.describe(`elements.${annotationTypes[key].id}`, {
-    _fallback: 'plugins.annotation'
-  });
-});
 
 export default {
   id: 'annotation',

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -1,0 +1,39 @@
+import {defaults} from 'chart.js';
+import BoxAnnotation from './box';
+import LineAnnotation from './line';
+import EllipseAnnotation from './ellipse';
+import LabelAnnotation from './label';
+import PointAnnotation from './point';
+import PolygonAnnotation from './polygon';
+
+export const annotationTypes = {
+  box: BoxAnnotation,
+  ellipse: EllipseAnnotation,
+  label: LabelAnnotation,
+  line: LineAnnotation,
+  point: PointAnnotation,
+  polygon: PolygonAnnotation
+};
+
+export {
+  BoxAnnotation,
+  LineAnnotation,
+  EllipseAnnotation,
+  LabelAnnotation,
+  PointAnnotation,
+  PolygonAnnotation
+};
+
+/**
+ * Register fallback for annotation elements
+ * For example lineAnnotation options would be looked through:
+ * - the annotation object (options.plugins.annotation.annotations[id])
+ * - element options (options.elements.lineAnnotation)
+ * - element defaults (defaults.elements.lineAnnotation)
+ * - annotation plugin defaults (defaults.plugins.annotation, this is what we are registering here)
+ */
+Object.keys(annotationTypes).forEach(key => {
+  defaults.describe(`elements.${annotationTypes[key].id}`, {
+    _fallback: 'plugins.annotation'
+  });
+});


### PR DESCRIPTION
As the number of types grow, they deserve their own index.