### PR TITLE
Log warning when unknown annotation type is used

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -16,3 +16,5 @@ beforeEach(function() {
 afterEach(function() {
   releaseCharts();
 });
+
+console.warn('Testing with chart.js v' + Chart.version);

--- a/test/specs/annotation.spec.js
+++ b/test/specs/annotation.spec.js
@@ -1,0 +1,41 @@
+describe('Annotation plugin', function() {
+  it('should emit console warning when unknown element type is used', function() {
+    const origWarn = console.warn;
+    console.warn = jasmine.createSpy('warn');
+
+    acquireChart({
+      type: 'line',
+      options: {
+        plugins: {
+          annotation: {
+            annotations: [{
+              id: 'test',
+              type: 'invalid'
+            }]
+          }
+        }
+      }
+    });
+
+    expect(console.warn).toHaveBeenCalledWith('Unknown annotation type: \'invalid\', defaulting to \'line\'');
+
+    acquireChart({
+      type: 'line',
+      options: {
+        plugins: {
+          annotation: {
+            annotations: {
+              test: {
+                type: 'invalid2'
+              }
+            }
+          }
+        }
+      }
+    });
+
+    expect(console.warn).toHaveBeenCalledWith('Unknown annotation type: \'invalid2\', defaulting to \'line\'');
+
+    console.warn = origWarn;
+  });
+});


### PR DESCRIPTION
There was also an issue when unknow type was used in the object notation of annotations.

The options resolver fallback was undefined and it resulted in error. This fixes the fallback to use `line` as well.