### PR TITLE
Add random seed reporting to test runs

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,4 @@
+const jasmineSeedReporter = require('./test/seed-reporter');
 const istanbul = require('rollup-plugin-istanbul');
 const json = require('@rollup/plugin-json');
 const resolve = require('@rollup/plugin-node-resolve').default;
@@ -27,7 +28,8 @@ module.exports = function(karma) {
 
   karma.set({
     frameworks: ['jasmine'],
-    reporters: ['progress', 'kjhtml'],
+    plugins: ['karma-*', jasmineSeedReporter],
+    reporters: ['progress', 'kjhtml', 'jasmine-seed'],
     browsers: (args.browsers || 'chrome,firefox').split(','),
     logLevel: karma.LOG_INFO,
 

--- a/test/seed-reporter.js
+++ b/test/seed-reporter.js
@@ -1,0 +1,13 @@
+const SeedReporter = function(baseReporterDecorator) {
+  baseReporterDecorator(this);
+
+  this.onBrowserComplete = function(browser, result) {
+    if (result.order && result.order.random && result.order.seed) {
+      this.write('%s: Randomized with seed %s\n', browser, result.order.seed);
+    }
+  };
+};
+
+module.exports = {
+  'reporter:jasmine-seed': ['type', SeedReporter]
+};


### PR DESCRIPTION
Prints out the random seed used to run the test.
Can be used to reproduce failures locally by passing `?seed=number` to the browser.

> Chrome 96.0.4664.93 (Windows 10): Executed 322 of 322 SUCCESS (10.253 secs / 8.953 secs)
> Chrome 96.0.4664.93 (Windows 10): Randomized with seed 21107

> Chrome 96.0.4664.93 (Windows 10): Executed 109 of 322 (1 FAILED) (3.673 secs / 3.379 secs)                                                                                                                                                                                                                                      
> Chrome 96.0.4664.93 (Windows 10): Randomized with seed 94637