### PR TITLE
Disclosure box sample is made responsive

### DIFF
--- a/docs/samples/box/disclosure.md
+++ b/docs/samples/box/disclosure.md
@@ -27,7 +27,7 @@ const annotation = {
     color: 'rgba(208,208,208,0.2)',
     content: 'Draft',
     font: {
-      size: 200
+      size: (ctx) => ctx.chart.chartArea.height / 1.5
     },
     position: 'center'
   }


### PR DESCRIPTION
The disclosure box annotation sample is made responsive because, in reality, the disclosure text must have a font size which depends on the height of chart area.