### PR TITLE
Build docs before releasing as latest/next

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -69,6 +69,11 @@ jobs:
           github_token: ${{ secrets.GH_AUTH_TOKEN }}
           publish_dir: dist/docs
           destination_dir: ${{ needs.setup.outputs.version }}
+      - name: Build docs (latest)
+        if: "!github.event.release.prerelease"
+        run: |
+          ./scripts/docs-config.sh latest
+          npm run docs
       - name: Release to GitHub Pages (latest)
         if: "!github.event.release.prerelease"
         uses: peaceiris/actions-gh-pages@v3
@@ -76,6 +81,11 @@ jobs:
           github_token: ${{ secrets.GH_AUTH_TOKEN }}
           publish_dir: dist/docs
           destination_dir: latest
+      - name: Build docs (next)
+        if: "github.event.release.prerelease"
+        run: |
+          ./scripts/docs-config.sh next
+          npm run docs
       - name: Release to GitHub Pages (next)
         if: "github.event.release.prerelease"
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
The release process did not build the docs for latest/next and this makes them not functional.

I've fixed the current latest docs already manually (https://github.com/chartjs/chartjs-plugin-annotation/commit/ab6328d48730560845c817d773007ad6e6ba933c). This should fix the release process for next release.

Please note that the cloudflare caching takes some time to notice the fixed version.

Closes #565 