### PR TITLE
Store drawable elements to the state

### DIFF
--- a/src/annotation.js
+++ b/src/annotation.js
@@ -23,6 +23,7 @@ export default {
     chartStates.set(chart, {
       annotations: [],
       elements: [],
+      drawableElements: [],
       listeners: {},
       listened: false,
       moveListened: false
@@ -139,6 +140,7 @@ function updateElements(chart, state, options, mode) {
 
   const annotations = state.annotations;
   const elements = resyncElements(state.elements, annotations);
+  const drawableElements = state.drawableElements = [];
 
   for (let i = 0; i < annotations.length; i++) {
     const annotation = annotations[i];
@@ -152,6 +154,9 @@ function updateElements(chart, state, options, mode) {
     properties.skip = isNaN(properties.x) || isNaN(properties.y);
     properties.options = opts;
     animations.update(el, properties);
+    if (!properties.skip && opts.display) {
+      drawableElements.push(el);
+    }
   }
 }
 
@@ -202,12 +207,11 @@ function resyncElements(elements, annotations) {
 function draw(chart, caller, clip) {
   const {ctx, chartArea} = chart;
   const state = chartStates.get(chart);
-  const elements = state.elements.filter(el => !el.skip && el.options.display);
 
   if (clip) {
     clipArea(ctx, chartArea);
   }
-  elements.forEach(el => {
+  state.drawableElements.forEach(el => {
     if (el.options.drawTime === caller) {
       el.draw(ctx);
     }
@@ -216,7 +220,7 @@ function draw(chart, caller, clip) {
     unclipArea(ctx);
   }
 
-  elements.forEach(el => {
+  state.drawableElements.forEach(el => {
     if ('drawLabel' in el && el.options.label && (el.options.label.drawTime || el.options.drawTime) === caller) {
       el.drawLabel(ctx, chartArea);
     }

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -144,11 +144,7 @@ function updateElements(chart, state, options, mode) {
 
   for (let i = 0; i < annotations.length; i++) {
     const annotation = annotations[i];
-    let el = elements[i];
-    const elementClass = annotationTypes[resolveType(annotation.type)];
-    if (!el || !(el instanceof elementClass)) {
-      el = elements[i] = new elementClass();
-    }
+    let el = elements[i] = createElement(annotation, elements[i]);
     const opts = resolveAnnotationOptions(annotation.setContext(getContext(chart, el, annotation)));
     const properties = el.resolveElementProperties(chart, opts);
     properties.skip = isNaN(properties.x) || isNaN(properties.y);
@@ -158,6 +154,14 @@ function updateElements(chart, state, options, mode) {
       drawableElements.push(el);
     }
   }
+}
+
+function createElement(annotation, element) {
+  const elementClass = annotationTypes[resolveType(annotation.type)];
+  if (!element || !(element instanceof elementClass)) {
+    return new elementClass();
+  }
+  return element;
 }
 
 function resolveAnnotationOptions(resolver) {


### PR DESCRIPTION
Calculating the drawable elements once per chart update and storing them in the state, this PR is improving the performance of annotations drawing.
