### PR TITLE
Move scale management functions to a dedicated file

### DIFF
--- a/src/annotation.js
+++ b/src/annotation.js
@@ -1,6 +1,7 @@
 import {Animations, Chart} from 'chart.js';
-import {clipArea, unclipArea, isFinite, valueOrDefault, isObject, isArray} from 'chart.js/helpers';
+import {clipArea, unclipArea, isObject, isArray} from 'chart.js/helpers';
 import {handleEvent, hooks, updateListeners} from './events';
+import {adjustScaleRange, verifyScaleOptions} from './scale';
 import {annotationTypes} from './types';
 import {version} from '../package.json';
 
@@ -221,64 +222,4 @@ function draw(chart, caller, clip) {
       el.drawLabel(ctx, chartArea);
     }
   });
-}
-
-function adjustScaleRange(chart, scale, annotations) {
-  const range = getScaleLimits(scale, annotations);
-  let changed = false;
-  if (isFinite(range.min) &&
-		typeof scale.options.min === 'undefined' &&
-		typeof scale.options.suggestedMin === 'undefined') {
-    changed = scale.min !== range.min;
-    scale.min = range.min;
-  }
-  if (isFinite(range.max) &&
-		typeof scale.options.max === 'undefined' &&
-		typeof scale.options.suggestedMax === 'undefined') {
-    changed = scale.max !== range.max;
-    scale.max = range.max;
-  }
-  if (changed && typeof scale.handleTickRangeOptions === 'function') {
-    scale.handleTickRangeOptions();
-  }
-}
-
-function getScaleLimits(scale, annotations) {
-  const axis = scale.axis;
-  const scaleID = scale.id;
-  const scaleIDOption = axis + 'ScaleID';
-  let min = valueOrDefault(scale.min, Number.NEGATIVE_INFINITY);
-  let max = valueOrDefault(scale.max, Number.POSITIVE_INFINITY);
-  for (const annotation of annotations) {
-    if (annotation.scaleID === scaleID) {
-      for (const prop of ['value', 'endValue']) {
-        const raw = annotation[prop];
-        if (raw) {
-          const value = scale.parse(raw);
-          min = Math.min(min, value);
-          max = Math.max(max, value);
-        }
-      }
-    } else if (annotation[scaleIDOption] === scaleID) {
-      for (const prop of [axis + 'Min', axis + 'Max', axis + 'Value']) {
-        const raw = annotation[prop];
-        if (raw) {
-          const value = scale.parse(raw);
-          min = Math.min(min, value);
-          max = Math.max(max, value);
-        }
-      }
-    }
-  }
-  return {min, max};
-}
-
-function verifyScaleOptions(annotations, scales) {
-  for (const annotation of annotations) {
-    for (const key of ['scaleID', 'xScaleID', 'yScaleID']) {
-      if (annotation[key] && !scales[annotation[key]]) {
-        console.warn(`No scale found with id '${annotation[key]}' for annotation '${annotation.id}'`);
-      }
-    }
-  }
 }

--- a/src/scale.js
+++ b/src/scale.js
@@ -2,7 +2,19 @@ import {isFinite, valueOrDefault} from 'chart.js/helpers';
 
 export function adjustScaleRange(chart, scale, annotations) {
   const range = getScaleLimits(scale, annotations);
-  let changed = changeScaleLimit(scale, range, 'min', 'suggestedMin') || changeScaleLimit(scale, range, 'max', 'suggestedMax');
+  let changed = false;
+  if (isFinite(range.min) &&
+		typeof scale.options.min === 'undefined' &&
+		typeof scale.options.suggestedMin === 'undefined') {
+    changed = scale.min !== range.min;
+    scale.min = range.min;
+  }
+  if (isFinite(range.max) &&
+		typeof scale.options.max === 'undefined' &&
+		typeof scale.options.suggestedMax === 'undefined') {
+    changed = scale.max !== range.max;
+    scale.max = range.max;
+  }
   if (changed && typeof scale.handleTickRangeOptions === 'function') {
     scale.handleTickRangeOptions();
   }
@@ -10,25 +22,10 @@ export function adjustScaleRange(chart, scale, annotations) {
 
 export function verifyScaleOptions(annotations, scales) {
   for (const annotation of annotations) {
-    verifyScaleIDs(annotation, scales);
-  }
-}
-
-function changeScaleLimit(scale, range, limit, suggestedLimit) {
-  if (isFinite(range[limit]) &&
-		typeof scale.options[limit] === 'undefined' &&
-		typeof scale.options[suggestedLimit] === 'undefined') {
-    const changed = scale[limit] !== range[limit];
-    scale[limit] = range[limit];
-    return changed;
-  }
-  return false;
-}
-
-function verifyScaleIDs(annotation, scales) {
-  for (const key of ['scaleID', 'xScaleID', 'yScaleID']) {
-    if (annotation[key] && !scales[annotation[key]]) {
-      console.warn(`No scale found with id '${annotation[key]}' for annotation '${annotation.id}'`);
+    for (const key of ['scaleID', 'xScaleID', 'yScaleID']) {
+      if (annotation[key] && !scales[annotation[key]]) {
+        console.warn(`No scale found with id '${annotation[key]}' for annotation '${annotation.id}'`);
+      }
     }
   }
 }
@@ -37,27 +34,28 @@ function getScaleLimits(scale, annotations) {
   const axis = scale.axis;
   const scaleID = scale.id;
   const scaleIDOption = axis + 'ScaleID';
-  const limits = {
-    min: valueOrDefault(scale.min, Number.NEGATIVE_INFINITY),
-    max: valueOrDefault(scale.max, Number.POSITIVE_INFINITY)
-  };
+  let min = valueOrDefault(scale.min, Number.NEGATIVE_INFINITY);
+  let max = valueOrDefault(scale.max, Number.POSITIVE_INFINITY);
   for (const annotation of annotations) {
     if (annotation.scaleID === scaleID) {
-      updateLimits(annotation, scale, ['value', 'endValue'], limits);
+      for (const prop of ['value', 'endValue']) {
+        const raw = annotation[prop];
+        if (raw) {
+          const value = scale.parse(raw);
+          min = Math.min(min, value);
+          max = Math.max(max, value);
+        }
+      }
     } else if (annotation[scaleIDOption] === scaleID) {
-      updateLimits(annotation, scale, [axis + 'Min', axis + 'Max', axis + 'Value'], limits);
+      for (const prop of [axis + 'Min', axis + 'Max', axis + 'Value']) {
+        const raw = annotation[prop];
+        if (raw) {
+          const value = scale.parse(raw);
+          min = Math.min(min, value);
+          max = Math.max(max, value);
+        }
+      }
     }
   }
-  return limits;
-}
-
-function updateLimits(annotation, scale, props, limits) {
-  for (const prop of props) {
-    const raw = annotation[prop];
-    if (raw) {
-      const value = scale.parse(raw);
-      limits.min = Math.min(limits.min, value);
-      limits.max = Math.max(limits.max, value);
-    }
-  }
+  return {min, max};
 }

--- a/src/scale.js
+++ b/src/scale.js
@@ -2,19 +2,7 @@ import {isFinite, valueOrDefault} from 'chart.js/helpers';
 
 export function adjustScaleRange(chart, scale, annotations) {
   const range = getScaleLimits(scale, annotations);
-  let changed = false;
-  if (isFinite(range.min) &&
-		typeof scale.options.min === 'undefined' &&
-		typeof scale.options.suggestedMin === 'undefined') {
-    changed = scale.min !== range.min;
-    scale.min = range.min;
-  }
-  if (isFinite(range.max) &&
-		typeof scale.options.max === 'undefined' &&
-		typeof scale.options.suggestedMax === 'undefined') {
-    changed = scale.max !== range.max;
-    scale.max = range.max;
-  }
+  let changed = changeScaleLimit(scale, range, 'min', 'suggestedMin') || changeScaleLimit(scale, range, 'max', 'suggestedMax');
   if (changed && typeof scale.handleTickRangeOptions === 'function') {
     scale.handleTickRangeOptions();
   }
@@ -22,10 +10,25 @@ export function adjustScaleRange(chart, scale, annotations) {
 
 export function verifyScaleOptions(annotations, scales) {
   for (const annotation of annotations) {
-    for (const key of ['scaleID', 'xScaleID', 'yScaleID']) {
-      if (annotation[key] && !scales[annotation[key]]) {
-        console.warn(`No scale found with id '${annotation[key]}' for annotation '${annotation.id}'`);
-      }
+    verifyScaleIDs(annotation, scales);
+  }
+}
+
+function changeScaleLimit(scale, range, limit, suggestedLimit) {
+  if (isFinite(range[limit]) &&
+		typeof scale.options[limit] === 'undefined' &&
+		typeof scale.options[suggestedLimit] === 'undefined') {
+    const changed = scale[limit] !== range[limit];
+    scale[limit] = range[limit];
+    return changed;
+  }
+  return false;
+}
+
+function verifyScaleIDs(annotation, scales) {
+  for (const key of ['scaleID', 'xScaleID', 'yScaleID']) {
+    if (annotation[key] && !scales[annotation[key]]) {
+      console.warn(`No scale found with id '${annotation[key]}' for annotation '${annotation.id}'`);
     }
   }
 }
@@ -34,28 +37,27 @@ function getScaleLimits(scale, annotations) {
   const axis = scale.axis;
   const scaleID = scale.id;
   const scaleIDOption = axis + 'ScaleID';
-  let min = valueOrDefault(scale.min, Number.NEGATIVE_INFINITY);
-  let max = valueOrDefault(scale.max, Number.POSITIVE_INFINITY);
+  const limits = {
+    min: valueOrDefault(scale.min, Number.NEGATIVE_INFINITY),
+    max: valueOrDefault(scale.max, Number.POSITIVE_INFINITY)
+  };
   for (const annotation of annotations) {
     if (annotation.scaleID === scaleID) {
-      for (const prop of ['value', 'endValue']) {
-        const raw = annotation[prop];
-        if (raw) {
-          const value = scale.parse(raw);
-          min = Math.min(min, value);
-          max = Math.max(max, value);
-        }
-      }
+      updateLimits(annotation, scale, ['value', 'endValue'], limits);
     } else if (annotation[scaleIDOption] === scaleID) {
-      for (const prop of [axis + 'Min', axis + 'Max', axis + 'Value']) {
-        const raw = annotation[prop];
-        if (raw) {
-          const value = scale.parse(raw);
-          min = Math.min(min, value);
-          max = Math.max(max, value);
-        }
-      }
+      updateLimits(annotation, scale, [axis + 'Min', axis + 'Max', axis + 'Value'], limits);
     }
   }
-  return {min, max};
+  return limits;
+}
+
+function updateLimits(annotation, scale, props, limits) {
+  for (const prop of props) {
+    const raw = annotation[prop];
+    if (raw) {
+      const value = scale.parse(raw);
+      limits.min = Math.min(limits.min, value);
+      limits.max = Math.max(limits.max, value);
+    }
+  }
 }

--- a/src/scale.js
+++ b/src/scale.js
@@ -1,0 +1,61 @@
+import {isFinite, valueOrDefault} from 'chart.js/helpers';
+
+export function adjustScaleRange(chart, scale, annotations) {
+  const range = getScaleLimits(scale, annotations);
+  let changed = false;
+  if (isFinite(range.min) &&
+		typeof scale.options.min === 'undefined' &&
+		typeof scale.options.suggestedMin === 'undefined') {
+    changed = scale.min !== range.min;
+    scale.min = range.min;
+  }
+  if (isFinite(range.max) &&
+		typeof scale.options.max === 'undefined' &&
+		typeof scale.options.suggestedMax === 'undefined') {
+    changed = scale.max !== range.max;
+    scale.max = range.max;
+  }
+  if (changed && typeof scale.handleTickRangeOptions === 'function') {
+    scale.handleTickRangeOptions();
+  }
+}
+
+export function verifyScaleOptions(annotations, scales) {
+  for (const annotation of annotations) {
+    for (const key of ['scaleID', 'xScaleID', 'yScaleID']) {
+      if (annotation[key] && !scales[annotation[key]]) {
+        console.warn(`No scale found with id '${annotation[key]}' for annotation '${annotation.id}'`);
+      }
+    }
+  }
+}
+
+function getScaleLimits(scale, annotations) {
+  const axis = scale.axis;
+  const scaleID = scale.id;
+  const scaleIDOption = axis + 'ScaleID';
+  let min = valueOrDefault(scale.min, Number.NEGATIVE_INFINITY);
+  let max = valueOrDefault(scale.max, Number.POSITIVE_INFINITY);
+  for (const annotation of annotations) {
+    if (annotation.scaleID === scaleID) {
+      for (const prop of ['value', 'endValue']) {
+        const raw = annotation[prop];
+        if (raw) {
+          const value = scale.parse(raw);
+          min = Math.min(min, value);
+          max = Math.max(max, value);
+        }
+      }
+    } else if (annotation[scaleIDOption] === scaleID) {
+      for (const prop of [axis + 'Min', axis + 'Max', axis + 'Value']) {
+        const raw = annotation[prop];
+        if (raw) {
+          const value = scale.parse(raw);
+          min = Math.min(min, value);
+          max = Math.max(max, value);
+        }
+      }
+    }
+  }
+  return {min, max};
+}


### PR DESCRIPTION
This PR creates the scale module where there are some scale functions invoked from `annotation.js`.
These functions are NOT moved in a dedicated `helpers` or  in `helpers.chart` because they are invoked only from 1 point.

This is done to reduce the size of `annotation.js` and improving readability, concentrating all functions of the same topic in a dedicated module.