### PR TITLE
Change `var` to `const` in the samples

### DIFF
--- a/docs/samples/box/basic.md
+++ b/docs/samples/box/basic.md
@@ -20,8 +20,8 @@ const data = {
 // <block:annotation1:1>
 const annotation1 = {
   type: 'box',
-  backgroundColor: 'rgba(0,150,0,0.02)',
-  borderColor: 'rgba(0,150,0,0.2)',
+  backgroundColor: 'rgba(0, 150, 0, 0.02)',
+  borderColor: 'rgba(0, 150, 0, 0.2)',
   borderRadius: 4,
   borderWidth: 1,
   xMax: (ctx) => max(ctx, 0, 'x') + 2,
@@ -34,8 +34,8 @@ const annotation1 = {
 // <block:annotation2:2>
 const annotation2 = {
   type: 'box',
-  backgroundColor: 'rgba(150,0,0,0.02)',
-  borderColor: 'rgba(150,0,0,0.2)',
+  backgroundColor: 'rgba(150, 0, 0, 0.02)',
+  borderColor: 'rgba(150, 0, 0, 0.2)',
   borderRadius: 4,
   borderWidth: 1,
   xMax: (ctx) => max(ctx, 1, 'x') + 2,
@@ -75,7 +75,7 @@ function max(ctx, datasetIndex, prop) {
 
 // </block:utils>
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/box/disclosure.md
+++ b/docs/samples/box/disclosure.md
@@ -24,7 +24,7 @@ const annotation = {
   label: {
     drawTime: 'afterDatasetsDraw',
     enabled: true,
-    color: 'rgba(208,208,208,0.2)',
+    color: 'rgba(208, 208, 208, 0.2)',
     content: 'Draft',
     font: {
       size: (ctx) => ctx.chart.chartArea.height / 1.5
@@ -50,7 +50,7 @@ const config = {
 };
 /* </block:config> */
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/box/quarters.md
+++ b/docs/samples/box/quarters.md
@@ -19,7 +19,7 @@ const data = {
 // <block:annotation1:1>
 const annotation1 = {
   type: 'box',
-  backgroundColor: 'rgba(255,245,157,0.2)',
+  backgroundColor: 'rgba(255, 245, 157, 0.2)',
   borderWidth: 0,
   xMax: 2.5,
   xMin: -0.5,
@@ -38,7 +38,7 @@ const annotation1 = {
 // <block:annotation2:2>
 const annotation2 = {
   type: 'box',
-  backgroundColor: 'rgba(188,170,164,0.2)',
+  backgroundColor: 'rgba(188, 170, 164, 0.2)',
   borderWidth: 0,
   xMax: 5.5,
   xMin: 2.5,
@@ -57,7 +57,7 @@ const annotation2 = {
 // <block:annotation3:3>
 const annotation3 = {
   type: 'box',
-  backgroundColor: 'rgba(165,214,167,0.2)',
+  backgroundColor: 'rgba(165, 214, 167, 0.2)',
   borderWidth: 0,
   xMax: 8.5,
   xMin: 5.5,
@@ -76,7 +76,7 @@ const annotation3 = {
 // <block:annotation4:4>
 const annotation4 = {
   type: 'box',
-  backgroundColor: 'rgba(159,168,218,0.2)',
+  backgroundColor: 'rgba(159, 168, 218, 0.2)',
   borderWidth: 0,
   xMin: 8.5,
   label: {
@@ -118,7 +118,7 @@ const config = {
 };
 /* </block:config> */
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/charts/bar.md
+++ b/docs/samples/charts/bar.md
@@ -65,8 +65,8 @@ const annotation3 = {
   xMax: 3.5,
   yMin: 0,
   yMax: 100,
-  backgroundColor: 'rgba(250,250,0,0.4)',
-  borderColor: 'rgba(0,150,0,0.2)',
+  backgroundColor: 'rgba(250, 250, 0, 0.4)',
+  borderColor: 'rgba(0, 150, 0, 0.2)',
   drawTime: 'beforeDatasetsDraw',
   borderWidth: 0,
   borderRadius: 0,
@@ -92,7 +92,7 @@ const config = {
 };
 /* </block:config> */
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/charts/line.md
+++ b/docs/samples/charts/line.md
@@ -62,8 +62,8 @@ const annotation3 = {
   xMax: 85,
   yMin: 80,
   yMax: 90,
-  backgroundColor: 'rgba(250,250,0,0.4)',
-  borderColor: 'rgba(0,150,0,0.2)',
+  backgroundColor: 'rgba(250, 250, 0, 0.4)',
+  borderColor: 'rgba(0, 150, 0, 0.2)',
   drawTime: 'beforeDatasetsDraw',
   borderWidth: 0,
   borderRadius: 0,
@@ -95,7 +95,7 @@ const config = {
 };
 /* </block:config> */
 
-var actions = [
+const actions = [
   {
     name: 'Zoom out',
     handler: function(chart) {

--- a/docs/samples/ellipse/basic.md
+++ b/docs/samples/ellipse/basic.md
@@ -20,8 +20,8 @@ const data = {
 // <block:annotation1:1>
 const annotation1 = {
   type: 'ellipse',
-  backgroundColor: 'rgba(0,150,0,0.02)',
-  borderColor: 'rgba(0,150,0,0.2)',
+  backgroundColor: 'rgba(0, 150, 0, 0.02)',
+  borderColor: 'rgba(0, 150, 0, 0.2)',
   borderWidth: 1,
   xMax: (ctx) => max(ctx, 0, 'x') + 10,
   xMin: (ctx) => min(ctx, 0, 'x') - 10,
@@ -33,8 +33,8 @@ const annotation1 = {
 // <block:annotation2:2>
 const annotation2 = {
   type: 'ellipse',
-  backgroundColor: 'rgba(150,0,0,0.02)',
-  borderColor: 'rgba(150,0,0,0.2)',
+  backgroundColor: 'rgba(150, 0, 0, 0.02)',
+  borderColor: 'rgba(150, 0, 0, 0.2)',
   borderWidth: 1,
   xMax: (ctx) => max(ctx, 1, 'x') + 10,
   xMin: (ctx) => min(ctx, 1, 'x') - 10,
@@ -73,7 +73,7 @@ function max(ctx, datasetIndex, prop) {
 
 // </block:utils>
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/ellipse/rotation.md
+++ b/docs/samples/ellipse/rotation.md
@@ -20,8 +20,8 @@ const data = {
 // <block:annotation1:1>
 const annotation1 = {
   type: 'ellipse',
-  backgroundColor: 'rgba(0,150,0,0.02)',
-  borderColor: 'rgba(0,150,0,0.2)',
+  backgroundColor: 'rgba(0, 150, 0, 0.02)',
+  borderColor: 'rgba(0, 150, 0, 0.2)',
   borderWidth: 1,
   rotation: 90,
   xMax: (ctx) => max(ctx, 0, 'x') + 10,
@@ -34,8 +34,8 @@ const annotation1 = {
 // <block:annotation2:2>
 const annotation2 = {
   type: 'ellipse',
-  backgroundColor: 'rgba(150,0,0,0.02)',
-  borderColor: 'rgba(150,0,0,0.2)',
+  backgroundColor: 'rgba(150, 0, 0, 0.02)',
+  borderColor: 'rgba(150, 0, 0, 0.2)',
   borderWidth: 1,
   rotation: 90,
   xMax: (ctx) => max(ctx, 1, 'x') + 10,
@@ -87,7 +87,7 @@ function max(ctx, datasetIndex, prop) {
 
 // </block:utils>
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/intro.md
+++ b/docs/samples/intro.md
@@ -83,7 +83,7 @@ const config = {
 };
 /* </block:config> */
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/label/basic.md
+++ b/docs/samples/label/basic.md
@@ -102,7 +102,7 @@ function yValue(ctx, label) {
 }
 // </block:utils>
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/label/callout.md
+++ b/docs/samples/label/callout.md
@@ -19,7 +19,7 @@ const data = {
 // <block:annotation:1>
 const annotation = {
   type: 'label',
-  backgroundColor: 'rgba(245,245,245)',
+  backgroundColor: 'rgba(245, 245, 245)',
   callout: {
     enabled: true,
     borderColor: (ctx) => ctx.chart.data.datasets[0].borderColor
@@ -79,7 +79,7 @@ function maxLabel(ctx) {
 }
 // </block:utils>
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/label/lowerUpper.md
+++ b/docs/samples/label/lowerUpper.md
@@ -101,7 +101,7 @@ function maxValue(ctx) {
 }
 // </block:utils>
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/label/point.md
+++ b/docs/samples/label/point.md
@@ -19,7 +19,7 @@ const data = {
 // <block:annotation1:1>
 const annotation1 = {
   type: 'label',
-  backgroundColor: 'rgba(245,245,245, 0.5)',
+  backgroundColor: 'rgba(245, 245, 245, 0.5)',
   content: (ctx) => 'Maximum value is ' + maxValue(ctx).toFixed(2),
   font: {
     size: 16
@@ -110,7 +110,7 @@ function maxLabel(ctx) {
 }
 // </block:utils>
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/line/animation.md
+++ b/docs/samples/line/animation.md
@@ -8,8 +8,8 @@ const uniqueId = new Date().getTime();
 
 const data = {
   datasets: [{
-    backgroundColor: 'rgba(63,184,175,0.3)',
-    borderColor: 'rgba(255,0,0,0.0)',
+    backgroundColor: 'rgba(63, 184, 175, 0.3)',
+    borderColor: 'rgba(255, 0, 0, 0.0)',
     pointRadius: 0, // no dots
     tension: 0, // straight lines
     showLine: true,

--- a/docs/samples/line/average.md
+++ b/docs/samples/line/average.md
@@ -63,7 +63,7 @@ function average(ctx) {
 }
 // </block:utils>
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/line/basic.md
+++ b/docs/samples/line/basic.md
@@ -54,7 +54,7 @@ const config = {
 };
 /* </block:config> */
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/line/labelVisibility.md
+++ b/docs/samples/line/labelVisibility.md
@@ -85,7 +85,7 @@ function toggleLabel(ctx, event) {
 }
 // </block:utils>
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/line/lowerUpper.md
+++ b/docs/samples/line/lowerUpper.md
@@ -109,7 +109,7 @@ function maxValue(ctx) {
 }
 // </block:utils>
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/line/standardDeviation.md
+++ b/docs/samples/line/standardDeviation.md
@@ -26,13 +26,13 @@ const data = {
 // <block:annotation1:1>
 const annotation1 = {
   type: 'line',
-  borderColor: 'rgb(100,149,237)',
+  borderColor: 'rgb(100, 149, 237)',
   borderDash: [6, 6],
   borderDashOffset: 0,
   borderWidth: 3,
   label: {
     enabled: true,
-    backgroundColor: 'rgba(100,149,237)',
+    backgroundColor: 'rgb(100, 149, 237)',
     content: (ctx) => 'Average: ' + average(ctx).toFixed(2)
   },
   scaleID: 'y',
@@ -43,13 +43,13 @@ const annotation1 = {
 // <block:annotation2:2>
 const annotation2 = {
   type: 'line',
-  borderColor: 'rgba(102,102,102,0.5)',
+  borderColor: 'rgba(102, 102, 102, 0.5)',
   borderDash: [6, 6],
   borderDashOffset: 0,
   borderWidth: 3,
   label: {
     enabled: true,
-    backgroundColor: 'rgba(102,102,102,0.5)',
+    backgroundColor: 'rgba(102, 102, 102, 0.5)',
     color: 'black',
     content: (ctx) => (average(ctx) + standardDeviation(ctx)).toFixed(2),
     position: 'start',
@@ -64,13 +64,13 @@ const annotation2 = {
 // <block:annotation3:3>
 const annotation3 = {
   type: 'line',
-  borderColor: 'rgba(102,102,102,0.5)',
+  borderColor: 'rgba(102, 102, 102, 0.5)',
   borderDash: [6, 6],
   borderDashOffset: 0,
   borderWidth: 3,
   label: {
     enabled: true,
-    backgroundColor: 'rgba(102,102,102,0.5)',
+    backgroundColor: 'rgba(102, 102, 102, 0.5)',
     color: 'black',
     content: (ctx) => (average(ctx) - standardDeviation(ctx)).toFixed(2),
     position: 'end',
@@ -122,7 +122,7 @@ function standardDeviation(ctx) {
 
 // </block:utils>
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/point/basic.md
+++ b/docs/samples/point/basic.md
@@ -30,7 +30,7 @@ const data = {
 // <block:annotation1:1>
 const annotation1 = {
   type: 'point',
-  backgroundColor: 'rgba(0,255,255,0.4)',
+  backgroundColor: 'rgba(0, 255, 255, 0.4)',
   borderColor: 'black',
   borderWidth: 3,
   scaleID: 'y',
@@ -93,7 +93,7 @@ function value(ctx, datasetIndex, index, prop) {
 }
 // </block:utils>
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/polygon/basic.md
+++ b/docs/samples/polygon/basic.md
@@ -30,7 +30,7 @@ const data = {
 // <block:annotation1:1>
 const annotation1 = {
   type: 'polygon',
-  backgroundColor: 'rgba(0,255,255,0.4)',
+  backgroundColor: 'rgba(0, 255, 255, 0.4)',
   borderColor: 'black',
   borderWidth: 3,
   radius: 25,
@@ -94,7 +94,7 @@ function value(ctx, datasetIndex, index, prop) {
 }
 // </block:utils>
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {

--- a/docs/samples/polygon/stop.md
+++ b/docs/samples/polygon/stop.md
@@ -129,7 +129,7 @@ function value(ctx, datasetIndex, index, prop) {
 }
 // </block:utils>
 
-var actions = [
+const actions = [
   {
     name: 'Randomize',
     handler: function(chart) {


### PR DESCRIPTION
This PR changes the samples where the actions were defined as `var`, instead of `const`.
it changes also the color definitions, where needed, adding a blank after the number