### PR TITLE
new annotation types added to ElementOptionsByType

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 import { ChartType, Plugin } from 'chart.js';
-import { AnnotationPluginOptions, BoxAnnotationOptions, EllipseAnnotationOptions, LineAnnotationOptions, PointAnnotationOptions } from './options';
+import { AnnotationPluginOptions, BoxAnnotationOptions, EllipseAnnotationOptions, LabelAnnotationOptions, LineAnnotationOptions, PointAnnotationOptions, PolygonAnnotationOptions } from './options';
 
 declare module 'chart.js' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -9,9 +9,11 @@ declare module 'chart.js' {
 
   interface ElementOptionsByType<TType extends ChartType> {
     boxAnnotation: BoxAnnotationOptions;
-    lineAnnotation: LineAnnotationOptions;
     ellipseAnnotation: EllipseAnnotationOptions;
+    labelAnnotation: LabelAnnotationOptions;
+    lineAnnotation: LineAnnotationOptions;
     pointAnnotation: PointAnnotationOptions;
+    polygonAnnotation: PolygonAnnotationOptions;
   }
 }
 


### PR DESCRIPTION
New annotation types added to ElementOptionsByType to be able to set defaults in typescript with correct typings like:

```
import { defaults } from 'chart.js';

defaults.elements.labelAnnotation.font = {
    color: '#999'
};
```