### PR TITLE
Normalize border style setting

### DIFF
--- a/src/types/ellipse.js
+++ b/src/types/ellipse.js
@@ -1,6 +1,6 @@
 import {Element} from 'chart.js';
 import {toRadians} from 'chart.js/helpers';
-import {getRectCenterPoint, getChartRect} from '../helpers';
+import {getRectCenterPoint, getChartRect, setBorderStyle} from '../helpers';
 
 export default class EllipseAnnotation extends Element {
 
@@ -22,21 +22,14 @@ export default class EllipseAnnotation extends Element {
     if (options.rotation) {
       ctx.rotate(toRadians(options.rotation));
     }
-
     ctx.beginPath();
-
-    ctx.lineWidth = options.borderWidth;
-    ctx.strokeStyle = options.borderColor;
     ctx.fillStyle = options.backgroundColor;
-
-    ctx.setLineDash(options.borderDash);
-    ctx.lineDashOffset = options.borderDashOffset;
-
+    const stroke = setBorderStyle(ctx, options);
     ctx.ellipse(0, 0, height / 2, width / 2, Math.PI / 2, 0, 2 * Math.PI);
-
     ctx.fill();
-    ctx.stroke();
-
+    if (stroke) {
+      ctx.stroke();
+    }
     ctx.restore();
   }
 

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -1,6 +1,6 @@
 import {Element} from 'chart.js';
 import {toRadians, toPadding} from 'chart.js/helpers';
-import {clamp, scaleValue, rotated, drawBox, drawLabel, measureLabelSize, getRelativePosition} from '../helpers';
+import {clamp, scaleValue, rotated, drawBox, drawLabel, measureLabelSize, getRelativePosition, setBorderStyle} from '../helpers';
 
 const PI = Math.PI;
 const pointInLine = (p1, p2, t) => ({x: p1.x + t * (p2.x - p1.x), y: p1.y + t * (p2.y - p1.y)});
@@ -103,13 +103,8 @@ export default class LineAnnotation extends Element {
     const {x, y, x2, y2, options} = this;
     ctx.save();
 
-    ctx.lineWidth = options.borderWidth;
-    ctx.strokeStyle = options.borderColor;
-    ctx.setLineDash(options.borderDash);
-    ctx.lineDashOffset = options.borderDashOffset;
-
-    // Draw
     ctx.beginPath();
+    setBorderStyle(ctx, options);
     ctx.moveTo(x, y);
     ctx.lineTo(x2, y2);
     ctx.stroke();


### PR DESCRIPTION
All annotations are using `setBorderStyle` function to set the border options to canvas context.
This could be helpful for shadowing impl.