### PR TITLE
Use PI constant of Chartjs helpers instead of Math.PI

### DIFF
--- a/src/types/ellipse.js
+++ b/src/types/ellipse.js
@@ -1,5 +1,5 @@
 import {Element} from 'chart.js';
-import {toRadians} from 'chart.js/helpers';
+import {PI, toRadians} from 'chart.js/helpers';
 import {getRectCenterPoint, getChartRect} from '../helpers';
 
 export default class EllipseAnnotation extends Element {
@@ -32,7 +32,7 @@ export default class EllipseAnnotation extends Element {
     ctx.setLineDash(options.borderDash);
     ctx.lineDashOffset = options.borderDashOffset;
 
-    ctx.ellipse(0, 0, height / 2, width / 2, Math.PI / 2, 0, 2 * Math.PI);
+    ctx.ellipse(0, 0, height / 2, width / 2, PI / 2, 0, 2 * PI);
 
     ctx.fill();
     ctx.stroke();

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -1,8 +1,7 @@
 import {Element} from 'chart.js';
-import {toRadians, toPadding} from 'chart.js/helpers';
+import {PI, toRadians, toPadding} from 'chart.js/helpers';
 import {clamp, scaleValue, rotated, drawBox, drawLabel, measureLabelSize, getRelativePosition} from '../helpers';
 
-const PI = Math.PI;
 const pointInLine = (p1, p2, t) => ({x: p1.x + t * (p2.x - p1.x), y: p1.y + t * (p2.y - p1.y)});
 const interpolateX = (y, p1, p2) => pointInLine(p1, p2, Math.abs((y - p1.y) / (p2.y - p1.y))).x;
 const interpolateY = (x, p1, p2) => pointInLine(p1, p2, Math.abs((x - p1.x) / (p2.x - p1.x))).y;


### PR DESCRIPTION
Remove `Math.PI`, using the `PI` constant of Chartjs helpers