### PR TITLE
Add JSDoc to `labelIsVisible` method of line annotation

### DIFF
--- a/src/types/line.js
+++ b/src/types/line.js
@@ -43,7 +43,7 @@ function limitLineToArea(p1, p2, area) {
 }
 
 export default class LineAnnotation extends Element {
-  
+
   // TODO: make private in v2
   intersects(x, y, epsilon = 0.001, useFinalPosition) {
     // Adapted from https://stackoverflow.com/a/6853926/25507

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -66,8 +66,8 @@ export default class LineAnnotation extends Element {
     return (sqr(x - xx) + sqr(y - yy)) < epsilon;
   }
 
-  // TODO: make private in v2
   /**
+   * TODO: make private in v2
    * @param {boolean} useFinalPosition - use the element's animation target instead of current position
    * @param {top, right, bottom, left} [chartArea] - optional, area of the chart
    * @returns {boolean} true if the label is visible

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -43,6 +43,8 @@ function limitLineToArea(p1, p2, area) {
 }
 
 export default class LineAnnotation extends Element {
+  
+  // TODO: make private in v2
   intersects(x, y, epsilon = 0.001, useFinalPosition) {
     // Adapted from https://stackoverflow.com/a/6853926/25507
     const {x: x1, y: y1, x2, y2} = this.getProps(['x', 'y', 'x2', 'y2'], useFinalPosition);
@@ -65,6 +67,11 @@ export default class LineAnnotation extends Element {
   }
 
   // TODO: make private in v2
+  /**
+   * @param {boolean} useFinalPosition - use the element's animation target instead of current position
+   * @param {top, right, bottom, left} [chartArea] - optional, area of the chart
+   * @returns {boolean} true if the label is visible
+   */
   labelIsVisible(useFinalPosition, chartArea) {
     const labelOpts = this.options.label;
     if (!labelOpts || !labelOpts.enabled) {

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -67,7 +67,7 @@ export default class LineAnnotation extends Element {
   }
 
   /**
-   * TODO: make private in v2
+   * @todo make private in v2
    * @param {boolean} useFinalPosition - use the element's animation target instead of current position
    * @param {top, right, bottom, left} [chartArea] - optional, area of the chart
    * @returns {boolean} true if the label is visible


### PR DESCRIPTION
As shared in #603, this PR adds JSDoc to `labelIsVisible` method of line annotation, in order to be aware about the optional arguments.