### PR TITLE
Sort alphabetically the options definitions in the documentation

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -8,10 +8,10 @@ The following options are available at the top level. They apply to all annotati
 
 | Name | Type | [Scriptable](options#scriptable-options) | Default | Notes
 | ---- | ---- | :----: | ---- | ----
+| [`animations`](#animations) | `object` | No | [see here](#default-animations) | To configure which element properties are animated and how.
 | `clip` | `boolean` | No | `true` | Are the annotations clipped to the chartArea.
-| `drawTime` | `string` | Yes | `'afterDatasetsDraw'` | See [drawTime](options#draw-time)
 | `dblClickSpeed` | `number` | Yes | `350` | Time to detect a double click in ms.
-| [`animations`](#animations) | `object` | No | [see here](#default-animations) | To configure which element properties are animated and how
+| `drawTime` | `string` | Yes | `'afterDatasetsDraw'` | See [drawTime](options#draw-time).
 
 :::warning
 
@@ -63,7 +63,7 @@ The following options are available for all annotation types. These options can 
 
 | Name | Type | [Scriptable](options#scriptable-options) | Notes
 | ---- | ---- | :----: | ----
-| `enter` | `(context, event) => void` | No | Called when the mouse enters the annotation.
-| `leave` | `(context, event) => void` | No | Called when the mouse leaves the annotation.
 | `click` | `(context, event) => void` | No | Called when a single click occurs on the annotation.
 | `dblClick` | `(context, event) => void` | No | Called when a double click occurs on the annotation.
+| `enter` | `(context, event) => void` | No | Called when the mouse enters the annotation.
+| `leave` | `(context, event) => void` | No | Called when the mouse leaves the annotation.

--- a/docs/guide/types/box.md
+++ b/docs/guide/types/box.md
@@ -64,16 +64,16 @@ The following options are available for box annotations.
 | [`borderWidth`](#styling) | `number`| Yes | `1`
 | [`display`](#general) | `boolean` | Yes | `true`
 | [`drawTime`](#general) | `string` | Yes | `'afterDatasetsDraw'`
+| [`label`](#label) | `object` | Yes |
 | [`shadowBlur`](#styling) | `number` | Yes | `0`
 | [`shadowOffsetX`](#styling) | `number` | Yes | `0`
 | [`shadowOffsetY`](#styling) | `number` | Yes | `0`
-| [`xScaleID`](#general) | `string` | Yes | `'x'`
-| [`yScaleID`](#general) | `string` | Yes | `'y'`
-| [`xMin`](#general) | `number` \| `string` | Yes | `undefined`
 | [`xMax`](#general) | `number` \| `string` | Yes | `undefined`
+| [`xMin`](#general) | `number` \| `string` | Yes | `undefined`
+| [`xScaleID`](#general) | `string` | Yes | `'x'`
 | [`yMin`](#general) | `number` \| `string` | Yes | `undefined`
 | [`yMax`](#general) | `number` \| `string` | Yes | `undefined`
-| [`label`](#label) | `object` | Yes |
+| [`yScaleID`](#general) | `string` | Yes | `'y'`
 
 ### General
 
@@ -81,15 +81,15 @@ If one of the axes does not match an axis in the chart, the box will take the en
 
 | Name | Description |
 | ---- | ---- |
-| `display` | Whether or not this annotation is visible
-| `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range
-| `drawTime` | See [drawTime](../options#draw-time)
-| `xScaleID` | ID of the X scale to bind onto, default is 'x'.
-| `yScaleID` | ID of the Y scale to bind onto, default is 'y'.
-| `xMin` | Left edge of the box in units along the x axis.
+| `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
+| `display` | Whether or not this annotation is visible.
+| `drawTime` | See [drawTime](../options#draw-time).
 | `xMax` | Right edge of the box in units along the x axis.
-| `yMin` | Top edge of the box in units along the y axis.
+| `xMin` | Left edge of the box in units along the x axis.
+| `xScaleID` | ID of the X scale to bind onto, default is 'x'.
 | `yMax` | Bottom edge of the box in units along the y axis.
+| `yMin` | Top edge of the box in units along the y axis.
+| `yScaleID` | ID of the Y scale to bind onto, default is 'y'.
 
 ### Styling
 
@@ -97,12 +97,12 @@ If one of the axes does not match an axis in the chart, the box will take the en
 | ---- | ---- |
 | `backgroundColor` | Fill color.
 | `backgroundShadowColor` | The color of shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
-| `borderColor` | Stroke color.
 | `borderCapStyle` | Cap style of the border line. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap).
+| `borderColor` | Stroke color.
 | `borderDash` | Length and spacing of dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash).
 | `borderDashOffset` | Offset for border line dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset).
 | `borderJoinStyle` | Border line joint style. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineJoin).
-| [`borderRadius`](#borderradius) | Radius of box rectangle (in pixels)
+| [`borderRadius`](#borderradius) | Radius of box rectangle (in pixels).
 | `borderShadowColor` | The color of the border shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
 | `borderWidth` | Border line width (in pixels).
 | `shadowBlur` | The amount of blur applied to shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowBlur).

--- a/docs/guide/types/ellipse.md
+++ b/docs/guide/types/ellipse.md
@@ -51,26 +51,26 @@ The following options are available for ellipse annotations.
 
 | Name | Type | [Scriptable](../options#scriptable-options) | Default
 | ---- | ---- | :----: | ----
-| [`display`](#general) | `boolean` | Yes | `true`
 | [`adjustScaleRange`](#general) | `boolean` | Yes | `true`
-| [`drawTime`](#general) | `string` | Yes | `'afterDatasetsDraw'`
-| [`rotation`](#general) | `number`| Yes | `0`
-| [`xScaleID`](#general) | `string` | Yes | `'x'`
-| [`yScaleID`](#general) | `string` | Yes | `'y'`
-| [`xMin`](#general) | `number` \| `string` | Yes | `undefined`
-| [`xMax`](#general) | `number` \| `string` | Yes | `undefined`
-| [`yMin`](#general) | `number` \| `string` | Yes | `undefined`
-| [`yMax`](#general) | `number` \| `string` | Yes | `undefined`
+| [`backgroundColor`](#styling) | [`Color`](../options#color) | Yes | `options.color`
+| [`backgroundShadowColor`](#styling) | [`Color`](../options#color) | Yes | `'transparent'`
 | [`borderColor`](#styling) | [`Color`](../options#color) | Yes | `options.color`
-| [`borderWidth`](#styling) | `number`| Yes | `1`
 | [`borderDash`](#styling) | `number[]`| Yes | `[]`
 | [`borderDashOffset`](#styling) | `number`| Yes | `0`
 | [`borderShadowColor`](#styling) | [`Color`](../options#color) | Yes | `'transparent'`
-| [`backgroundColor`](#styling) | [`Color`](../options#color) | Yes | `options.color`
-| [`backgroundShadowColor`](#styling) | [`Color`](../options#color) | Yes | `'transparent'`
+| [`borderWidth`](#styling) | `number`| Yes | `1`
+| [`display`](#general) | `boolean` | Yes | `true`
+| [`drawTime`](#general) | `string` | Yes | `'afterDatasetsDraw'`
+| [`rotation`](#general) | `number`| Yes | `0`
 | [`shadowBlur`](#styling) | `number` | Yes | `0`
 | [`shadowOffsetX`](#styling) | `number` | Yes | `0`
 | [`shadowOffsetY`](#styling) | `number` | Yes | `0`
+| [`xMax`](#general) | `number` \| `string` | Yes | `undefined`
+| [`xMin`](#general) | `number` \| `string` | Yes | `undefined`
+| [`xScaleID`](#general) | `string` | Yes | `'x'`
+| [`yMax`](#general) | `number` \| `string` | Yes | `undefined`
+| [`yMin`](#general) | `number` \| `string` | Yes | `undefined`
+| [`yScaleID`](#general) | `string` | Yes | `'y'`
 
 ### General
 
@@ -78,29 +78,28 @@ If one of the axes does not match an axis in the chart, the ellipse will take th
 
 | Name | Description |
 | ---- | ---- |
-| `display` | Whether or not this annotation is visible
-| `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range
-| `drawTime` | See [drawTime](../options#draw-time)
+| `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
+| `display` | Whether or not this annotation is visible.
+| `drawTime` | See [drawTime](../options#draw-time).
 | `rotation` | Rotatation of the ellipse in degrees, default is 0.
-| `xScaleID` | ID of the X scale to bind onto, default is 'x'.
-| `yScaleID` | ID of the Y scale to bind onto, default is 'y'.
-| `xMin` | Left edge of the ellipse in units along the x axis.
 | `xMax` | Right edge of the ellipse in units along the x axis.
-| `yMin` | Top edge of the ellipse in units along the y axis.
+| `xMin` | Left edge of the ellipse in units along the x axis.
+| `xScaleID` | ID of the X scale to bind onto, default is 'x'.
 | `yMax` | Bottom edge of the ellipse in units along the y axis.
+| `yMin` | Top edge of the ellipse in units along the y axis.
+| `yScaleID` | ID of the Y scale to bind onto, default is 'y'.
 
 ### Styling
 
 | Name | Description |
 | ---- | ---- |
-| `borderColor` | Stroke color
-| `borderWidth` | Stroke width
+| `backgroundColor` | Fill color.
+| `backgroundShadowColor` | The color of shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
+| `borderColor` | Stroke color.
 | `borderDash` | Length and spacing of dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash).
 | `borderDashOffset` | Offset for line dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset).
 | `borderShadowColor` | The color of the border shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
-| `backgroundColor` | Fill color
-| `backgroundShadowColor` | The color of shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
-| `shadowColor` | The color of shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
+| `borderWidth` | Stroke width.
 | `shadowBlur` | The amount of blur applied to shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowBlur).
 | `shadowOffsetX` | The distance that shadow will be offset horizontally. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowOffsetX).
 | `shadowOffsetY` | The distance that shadow will be offset vertically. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowOffsetY).

--- a/docs/guide/types/label.md
+++ b/docs/guide/types/label.md
@@ -98,9 +98,9 @@ The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the bo
 
 | Name | Description |
 | ---- | ---- |
-| `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range
+| `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
 | `content` | The content to show in the text annotation.
-| `display` | Whether or not this annotation is visible
+| `display` | Whether or not this annotation is visible.
 | `drawTime` | See [drawTime](../options#draw-time).
 | `height` | Overrides the height of the image or canvas element. Could be set in pixel by a number, or in percentage of current height of image or canvas element by a string. If undefined, uses the height of the image or canvas element. It is used only when the content is an image or canvas element.
 | `padding` | The padding to add around the text label.

--- a/docs/guide/types/line.md
+++ b/docs/guide/types/line.md
@@ -50,27 +50,27 @@ The following options are available for line annotations. All of these options c
 
 | Name | Type | [Scriptable](../options#scriptable-options) | Default
 | ---- | ---- | ---- | :----: | ----
-| [`display`](#general) | `boolean` | Yes | `true`
 | [`adjustScaleRange`](#general) | `boolean` | Yes | `true`
-| [`drawTime`](#general) | `string` | Yes | `'afterDatasetsDraw'`
-| [`scaleID`](#positioning) | `string` | Yes | `undefined`
-| [`value`](#positioning) | `number` | Yes | `undefined`
-| [`endValue`](#positioning) | `number` | Yes | `undefined`
-| [`xScaleID`](#positioning) | `string` | Yes | `'x'`
-| [`yScaleID`](#positioning) | `string` | Yes | `'y'`
-| [`xMin`](#general) | `number` \| `string` | Yes | `undefined`
-| [`xMax`](#general) | `number` \| `string` | Yes | `undefined`
-| [`yMin`](#general) | `number` \| `string` | Yes | `undefined`
-| [`yMax`](#general) | `number` \| `string` | Yes | `undefined`
 | [`borderColor`](#styling) | [`Color`](../options#color) | Yes | `options.color`
-| [`borderWidth`](#styling) | `number` | Yes | `1`
 | [`borderDash`](#styling) | `number[]` | Yes | `[]`
 | [`borderDashOffset`](#styling) | `number` | Yes | `0`
-| [`label`](#label) | `object` | Yes |
 | [`borderShadowColor`](#styling) | [`Color`](../options#color) | Yes | `'transparent'`
+| [`borderWidth`](#styling) | `number` | Yes | `1`
+| [`display`](#general) | `boolean` | Yes | `true`
+| [`drawTime`](#general) | `string` | Yes | `'afterDatasetsDraw'`
+| [`endValue`](#positioning) | `number` | Yes | `undefined`
+| [`label`](#label) | `object` | Yes |
+| [`scaleID`](#positioning) | `string` | Yes | `undefined`
 | [`shadowBlur`](#styling) | `number` | Yes | `0`
 | [`shadowOffsetX`](#styling) | `number` | Yes | `0`
 | [`shadowOffsetY`](#styling) | `number` | Yes | `0`
+| [`value`](#positioning) | `number` | Yes | `undefined`
+| [`xMax`](#general) | `number` \| `string` | Yes | `undefined`
+| [`xMin`](#general) | `number` \| `string` | Yes | `undefined`
+| [`xScaleID`](#positioning) | `string` | Yes | `'x'`
+| [`yMax`](#general) | `number` \| `string` | Yes | `undefined`
+| [`yMin`](#general) | `number` \| `string` | Yes | `undefined`
+| [`yScaleID`](#positioning) | `string` | Yes | `'y'`
 
 ### General
 
@@ -85,9 +85,9 @@ The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the li
 
 | Name | Description |
 | ---- | ---- |
-| `display` | Whether or not this annotation is visible
-| `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range
-| `drawTime` | See [drawTime](../options#draw-time)
+| `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
+| `display` | Whether or not this annotation is visible.
+| `drawTime` | See [drawTime](../options#draw-time).
 
 ### Positioning
 
@@ -97,25 +97,25 @@ If `scaleID` is unset, then `xScaleID` and `yScaleID` are used to draw a line fr
 
 | Name | Description |
 | ---- | ---- |
+| `endValue` | End two of the line when a single scale is specified.
 | `scaleID` | ID of the scale in single scale mode. If unset, `xScaleID` and `yScaleID` are used.
 | `value` | End one of the line when a single scale is specified.
-| `endValue` | End two of the line when a single scale is specified.
-| `xScaleID` | ID of the X scale to bind onto, default is 'x'.
-| `yScaleID` | ID of the Y scale to bind onto, default is 'y'.
-| `xMin` | X coordinate of end one of the line in units along the x axis.
 | `xMax` | X coordinate of end two of the line in units along the x axis.
-| `yMin` | Y coordinate of end one of the line in units along the y axis.
+| `xMin` | X coordinate of end one of the line in units along the x axis.
+| `xScaleID` | ID of the X scale to bind onto, default is 'x'.
 | `yMax` | Y coordinate of end two of the line in units along the y axis.
+| `yMin` | Y coordinate of end one of the line in units along the y axis.
+| `yScaleID` | ID of the Y scale to bind onto, default is 'y'.
 
 ### Styling
 
 | Name | Description |
 | ---- | ---- |
-| `borderColor` | Stroke color
-| `borderWidth` | Stroke width
+| `borderColor` | Stroke color.
 | `borderDash` | Length and spacing of dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash).
 | `borderDashOffset` | Offset for line dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset).
 | `borderShadowColor` | The color of shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
+| `borderWidth` | Stroke width.
 | `shadowBlur` | The amount of blur applied to shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowBlur).
 | `shadowOffsetX` | The distance that shadow will be offset horizontally. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowOffsetX).
 | `shadowOffsetY` | The distance that shadow will be offset vertically. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowOffsetY).
@@ -140,22 +140,22 @@ All of these options can be [Scriptable](../options#scriptable-options)
 | `borderWidth` | `number` | `0` | The border line width (in pixels).
 | `color` | [`Color`](../options#color) | `'#fff'` | Text color.
 | `content` | `string`\|`string[]`\|[`Image`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image)\|[`HTMLCanvasElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement) | `null` | The content to show in the label.
-| `drawTime` | `string` | `options.drawTime` | See [drawTime](../options#draw-time). Defaults to the line annotation draw time if unset
+| `drawTime` | `string` | `options.drawTime` | See [drawTime](../options#draw-time). Defaults to the line annotation draw time if unset.
 | `enabled` | `boolean` | `false` | Whether or not the label is shown.
-| `font` | [`Font`](../options#font) | `{ style: 'bold' }` | Label font
+| `font` | [`Font`](../options#font) | `{ style: 'bold' }` | Label font.
 | `height` | `number`\|`string` | `undefined` | Overrides the height of the image or canvas element. Could be set in pixel by a number, or in percentage of current height of image or canvas element by a string. If undefined, uses the height of the image or canvas element. It is used only when the content is an image or canvas element.
 | `padding` | [`Padding`](../options#padding) | `6` | The padding to add around the text label.
-| `xPadding` | `number` | `6` | Padding of label to add left/right. This is **deprecated**. Use `padding`.
-| `yPadding` | `number` | `6` | Padding of label to add top/bottom. This is **deprecated**. Use `padding`.
 | `position` | `string` | `'center'` | Anchor position of label on line. Possible options are: `'start'`, `'center'`, `'end'`. It can be set by a string in percentage format `'number%'` which are representing the percentage on the width of the line where the label will be located.
-| `rotation` | `number`\|`'auto'` | `0` | Rotation of label, in degrees, or 'auto' to use the degrees of the line
+| `rotation` | `number`\|`'auto'` | `0` | Rotation of label, in degrees, or 'auto' to use the degrees of the line.
 | `shadowBlur` | `number` | `0` | The amount of blur applied to shadow of the box where the label is located. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowBlur).
 | `shadowOffsetX` | `number` | `0` | The distance that shadow, of the box where the label is located, will be offset horizontally. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowOffsetX).
 | `shadowOffsetY` | `number` | `0` | The distance that shadow, of the box where the label is located, will be offset vertically. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowOffsetY).
 | `textAlign` | `string` | `'center'` | Text alignment of label content when there's more than one line. Possible options are: `'start'`, `'center'`, `'end'`.
 | `width` | `number`\|`string` | `undefined` | Overrides the width of the image or canvas element. Could be set in pixel by a number, or in percentage of current width of image or canvas element by a string. If undefined, uses the width of the image or canvas element. It is used only when the content is an image or canvas element.
 | `xAdjust` | `number` | `0` | Adjustment along x-axis (left-right) of label relative to computed position. Negative values move the label left, positive right.
+| `xPadding` | `number` | `6` | Padding of label to add left/right. This is **deprecated**. Use `padding`.
 | `yAdjust` | `number` | `0` | Adjustment along y-axis (top-bottom) of label relative to computed position. Negative values move the label up, positive down.
+| `yPadding` | `number` | `6` | Padding of label to add top/bottom. This is **deprecated**. Use `padding`.
 
 #### borderRadius
 

--- a/docs/guide/types/polygon.md
+++ b/docs/guide/types/polygon.md
@@ -88,8 +88,8 @@ The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the bo
 
 | Name | Description |
 | ---- | ---- |
-| `display` | Whether or not this annotation is visible.
 | `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
+| `display` | Whether or not this annotation is visible.
 | `drawTime` | See [drawTime](../options#draw-time).
 | `radius` | Size of the polygon in pixels.
 | `rotation` | Rotation of polygon, in degrees.
@@ -109,15 +109,15 @@ The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the bo
 
 | Name | Description |
 | ---- | ---- |
-| `backgroundColor` | Fill color
+| `backgroundColor` | Fill color.
 | `backgroundShadowColor` | The color of shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
-| `borderColor` | Stroke color
+| `borderColor` | Stroke color.
 | `borderCapStyle` | Cap style of the border of polygon. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap).
 | `borderDash` | Length and spacing of dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash).
 | `borderDashOffset` | Offset for line dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset).
 | `borderJoinStyle` | Border line joint style. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineJoin).
 | `borderShadowColor` | The color of the border shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
-| `borderWidth` | Stroke width
+| `borderWidth` | Stroke width.
 | `shadowBlur` | The amount of blur applied to shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowBlur).
 | `shadowOffsetX` | The distance that shadow will be offset horizontally. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowOffsetX).
 | `shadowOffsetY` | The distance that shadow will be offset vertically. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowOffsetY).


### PR DESCRIPTION
Sort alphabetically the options definitions in the documentation.

As common practice, adds the dot at the end of the options description.