### PR TITLE
Enable the link to label configuration from the guide navigation menu

### DIFF
--- a/docs/guide/types/box.md
+++ b/docs/guide/types/box.md
@@ -113,7 +113,7 @@ If one of the axes does not match an axis in the chart, the box will take the en
 
 If this value is a number, it is applied to all corners of the rectangle (topLeft, topRight, bottomLeft, bottomRight). If this value is an object, the `topLeft` property defines the top-left corners border radius. Similarly, the `topRight`, `bottomLeft`, and `bottomRight` properties can also be specified. Omitted corners have radius of 0.
 
-### Label
+## Label
 
 Namespace: `options.annotations[annotationID].label`, it defines options for the box annotation label.
 

--- a/docs/guide/types/line.md
+++ b/docs/guide/types/line.md
@@ -120,7 +120,7 @@ If `scaleID` is unset, then `xScaleID` and `yScaleID` are used to draw a line fr
 | `shadowOffsetX` | The distance that shadow will be offset horizontally. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowOffsetX).
 | `shadowOffsetY` | The distance that shadow will be offset vertically. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowOffsetY).
 
-### Label
+## Label
 
 Namespace: `options.annotations[annotationID].label`, it defines options for the line annotation label.
 

--- a/docs/guide/types/polygon.md
+++ b/docs/guide/types/polygon.md
@@ -1,6 +1,6 @@
-# Polygin Annotations
+# Polygon Annotations
 
-Polygin annotations are used to mark whatever polygon (for instance triangle, square or pentagon) on the chart area. This can be useful for highlighting values that are of interest.
+Polygon annotations are used to mark whatever polygon (for instance triangle, square or pentagon) on the chart area. This can be useful for highlighting values that are of interest.
 
 ```js chart-editor
 /* <block:options:0> */


### PR DESCRIPTION
This PR enables the link to label config in the guide menu, for box and line annotations.

![image](https://user-images.githubusercontent.com/11741250/148221155-a4a84b1d-b243-4fbc-86cb-0f9f683853a0.png)
 
It fixes also a typo in the doc