### PR TITLE
Improve event handling adding test cases

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -31,12 +31,14 @@ export function updateListeners(chart, state, options) {
           }
         });
       }
-      moveHooks.forEach(hook => {
-        if (typeof scope[hook] === 'function') {
-          state.listened = true;
-          state.moveListened = true;
-        }
-      });
+      if (!state.moveListened) {
+        moveHooks.forEach(hook => {
+          if (typeof scope[hook] === 'function') {
+            state.listened = true;
+            state.moveListened = true;
+          }
+        });
+      }
     });
   }
 }

--- a/src/events.js
+++ b/src/events.js
@@ -31,14 +31,12 @@ export function updateListeners(chart, state, options) {
           }
         });
       }
-      if (!state.moveListened) {
-        moveHooks.forEach(hook => {
-          if (typeof scope[hook] === 'function') {
-            state.listened = true;
-            state.moveListened = true;
-          }
-        });
-      }
+      moveHooks.forEach(hook => {
+        if (typeof scope[hook] === 'function') {
+          state.listened = true;
+          state.moveListened = true;
+        }
+      });
     });
   }
 }

--- a/src/events.js
+++ b/src/events.js
@@ -5,7 +5,6 @@ const moveHooks = ['enter', 'leave'];
 export const hooks = clickHooks.concat(moveHooks);
 
 export function updateListeners(chart, state, options) {
-  const annotations = state.annotations || [];
   state.listened = false;
   state.moveListened = false;
 
@@ -24,7 +23,7 @@ export function updateListeners(chart, state, options) {
   });
 
   if (!state.listened || !state.moveListened) {
-    annotations.forEach(scope => {
+    state.annotations.forEach(scope => {
       if (!state.listened) {
         clickHooks.forEach(hook => {
           if (typeof scope[hook] === 'function') {

--- a/test/events.js
+++ b/test/events.js
@@ -146,6 +146,23 @@ export function testEvents(options, innerElement, getInnerPoint) {
         });
       });
 
+      it(`should not detect any events (because unmanaged event) on ${descr}`, function(done) {
+        const clickSpy = jasmine.createSpy('click');
+
+        targetOptions.click = clickSpy;
+        pluginOpts.annotations = [options];
+
+        const chart = window.acquireChart(chartConfig);
+        const eventPoint = getEventPoint(chart, getInnerPoint);
+
+        window.afterEvent(chart, 'touchstart', function() {
+          expect(clickSpy.calls.count()).toBe(0);
+          delete targetOptions.click;
+          done();
+        });
+        window.triggerMouseEvent(chart, 'touchstart', eventPoint);
+      });
+
       it(`should detect click event on ${descr}`, function(done) {
         const clickSpy = jasmine.createSpy('click');
 

--- a/test/events.js
+++ b/test/events.js
@@ -89,6 +89,60 @@ export function testEvents(options, innerElement, getInnerPoint) {
         });
       });
 
+      it(`should detect enter (by mousemove) and leave (by mouseout) events on ${descr}`, function(done) {
+        const enterSpy = jasmine.createSpy('enter');
+        const leaveSpy = jasmine.createSpy('leave');
+
+        targetOptions.enter = enterSpy;
+        targetOptions.leave = leaveSpy;
+        pluginOpts.annotations = [options];
+
+        const chart = window.acquireChart(chartConfig);
+        const eventPoint = getEventPoint(chart, getInnerPoint);
+
+        window.triggerMouseEvent(chart, 'mousemove', eventPoint);
+        window.afterEvent(chart, 'mousemove', function() {
+          expect(enterSpy.calls.count()).toBe(1);
+
+          window.triggerMouseEvent(chart, 'mouseout', {
+            x: 0,
+            y: 0
+          });
+
+          window.afterEvent(chart, 'mouseout', function() {
+            expect(leaveSpy.calls.count()).toBe(1);
+            delete targetOptions.enter;
+            delete targetOptions.leave;
+            done();
+          });
+        });
+      });
+
+      it(`should not detect any events on ${descr}`, function(done) {
+        const enterSpy = jasmine.createSpy('enter');
+        const leaveSpy = jasmine.createSpy('leave');
+
+        pluginOpts.annotations = [options];
+
+        const chart = window.acquireChart(chartConfig);
+        const eventPoint = getEventPoint(chart, getInnerPoint);
+
+        window.triggerMouseEvent(chart, 'mousemove', eventPoint);
+        window.afterEvent(chart, 'mousemove', function() {
+          expect(enterSpy.calls.count()).toBe(0);
+
+          window.triggerMouseEvent(chart, 'mousemove', {
+            x: 0,
+            y: 0
+          });
+
+          window.afterEvent(chart, 'mousemove', function() {
+            expect(leaveSpy.calls.count()).toBe(0);
+            done();
+          });
+        });
+      });
+
       it(`should detect click event on ${descr}`, function(done) {
         const clickSpy = jasmine.createSpy('click');
 

--- a/test/events.js
+++ b/test/events.js
@@ -118,6 +118,31 @@ export function testEvents(options, innerElement, getInnerPoint) {
         });
       });
 
+      it(`should not detect any events (because no callback is set) on ${descr}`, function(done) {
+        const enterSpy = jasmine.createSpy('enter');
+        const leaveSpy = jasmine.createSpy('leave');
+
+        pluginOpts.annotations = [options];
+
+        const chart = window.acquireChart(chartConfig);
+        const eventPoint = getEventPoint(chart, getInnerPoint);
+
+        window.triggerMouseEvent(chart, 'mousemove', eventPoint);
+        window.afterEvent(chart, 'mousemove', function() {
+          expect(enterSpy.calls.count()).toBe(0);
+
+          window.triggerMouseEvent(chart, 'mousemove', {
+            x: 0,
+            y: 0
+          });
+
+          window.afterEvent(chart, 'mousemove', function() {
+            expect(leaveSpy.calls.count()).toBe(0);
+            done();
+          });
+        });
+      });
+
       it(`should not detect any events on ${descr}`, function(done) {
         const enterSpy = jasmine.createSpy('enter');
         const leaveSpy = jasmine.createSpy('leave');

--- a/test/events.js
+++ b/test/events.js
@@ -121,7 +121,9 @@ export function testEvents(options, innerElement, getInnerPoint) {
       it(`should not detect any events on ${descr}`, function(done) {
         const enterSpy = jasmine.createSpy('enter');
         const leaveSpy = jasmine.createSpy('leave');
+        const clickSpy = jasmine.createSpy('click');
 
+        targetOptions.click = clickSpy;
         pluginOpts.annotations = [options];
 
         const chart = window.acquireChart(chartConfig);
@@ -138,6 +140,7 @@ export function testEvents(options, innerElement, getInnerPoint) {
 
           window.afterEvent(chart, 'mousemove', function() {
             expect(leaveSpy.calls.count()).toBe(0);
+            delete targetOptions.click;
             done();
           });
         });

--- a/test/specs/events.spec.js
+++ b/test/specs/events.spec.js
@@ -1,0 +1,87 @@
+describe('Events listeners state', function() {
+
+  const chartConfig = {
+    type: 'scatter',
+    options: {
+      animation: false,
+      scales: {
+        x: {
+          display: false,
+          min: 0,
+          max: 10
+        },
+        y: {
+          display: false,
+          min: 0,
+          max: 10
+        }
+      },
+      plugins: {
+        legend: false,
+        annotation: {
+          annotations: {
+          }
+        }
+      }
+    },
+  };
+
+  const pluginOpts = chartConfig.options.plugins.annotation.annotations;
+
+  it('should not throw any exception', function() {
+    const first = {
+      type: 'box',
+      xScaleID: 'x',
+      yScaleID: 'y',
+      xMin: 1,
+      yMin: 1,
+      xMax: 3,
+      yMax: 3
+    };
+
+    pluginOpts.first = first;
+
+    const chart = window.acquireChart(chartConfig);
+    const Annotation = window['chartjs-plugin-annotation'];
+    const state = Annotation._getState(chart);
+
+    expect(state.listened).toBe(false);
+    expect(state.moveListened).toBe(false);
+
+    const second = {
+      type: 'box',
+      xScaleID: 'x',
+      yScaleID: 'y',
+      xMin: 4,
+      yMin: 4,
+      xMax: 6,
+      yMax: 6,
+      enter() {
+      }
+    };
+
+    pluginOpts.second = second;
+    chart.update();
+
+    expect(state.listened).toBe(true);
+    expect(state.moveListened).toBe(true);
+
+    const third = {
+      type: 'box',
+      xScaleID: 'x',
+      yScaleID: 'y',
+      xMin: 7,
+      yMin: 7,
+      xMax: 9,
+      yMax: 9
+    };
+
+    pluginOpts.third = third;
+    chart.update();
+
+    expect(state.listened).toBe(true);
+    expect(state.moveListened).toBe(true);
+
+  });
+
+});

--- a/test/specs/events.spec.js
+++ b/test/specs/events.spec.js
@@ -19,65 +19,34 @@ describe('Events listeners state', function() {
       plugins: {
         legend: false,
         annotation: {
-          annotations: {
-          }
+          annotations: [
+            {
+              type: 'line',
+              scaleID: 'y',
+              value: 3
+            },
+            {
+              type: 'line',
+              scaleID: 'y',
+              value: 3,
+              enter: () => true
+            },
+            {
+              type: 'line',
+              scaleID: 'y',
+              value: 3
+            }
+          ]
         }
       }
     },
   };
 
-  const pluginOpts = chartConfig.options.plugins.annotation.annotations;
-
   it('should not throw any exception', function() {
-    const first = {
-      type: 'box',
-      xScaleID: 'x',
-      yScaleID: 'y',
-      xMin: 1,
-      yMin: 1,
-      xMax: 3,
-      yMax: 3
-    };
-
-    pluginOpts.first = first;
 
     const chart = window.acquireChart(chartConfig);
     const Annotation = window['chartjs-plugin-annotation'];
     const state = Annotation._getState(chart);
-
-    expect(state.listened).toBe(false);
-    expect(state.moveListened).toBe(false);
-
-    const second = {
-      type: 'box',
-      xScaleID: 'x',
-      yScaleID: 'y',
-      xMin: 4,
-      yMin: 4,
-      xMax: 6,
-      yMax: 6,
-      enter() {
-      }
-    };
-
-    pluginOpts.second = second;
-    chart.update();
-
-    expect(state.listened).toBe(true);
-    expect(state.moveListened).toBe(true);
-
-    const third = {
-      type: 'box',
-      xScaleID: 'x',
-      yScaleID: 'y',
-      xMin: 7,
-      yMin: 7,
-      xMax: 9,
-      yMax: 9
-    };
-
-    pluginOpts.third = third;
-    chart.update();
 
     expect(state.listened).toBe(true);
     expect(state.moveListened).toBe(true);


### PR DESCRIPTION
This PR is adding some additional test cases for event handling, in order to test specific condition in the code.

Furthermore it removes from `event.js` : 

1. a useless check on `state.annotations` because that instance can never be `undefined`. 
2. a if statement `if (!state.moveListened) {` because the `state.moveListened` could be always `false` to reach that code.
