### PR TITLE
Improve event handling on point annotation adding test cases

### DIFF
--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -7,11 +7,11 @@ export function clampAll(obj, from, to) {
   return obj;
 }
 
-export function inPointRange(point, center, radius) {
+export function inPointRange(point, center, radius, borderWidth) {
   if (!point || !center || radius <= 0) {
     return false;
   }
-  return (Math.pow(point.x - center.x, 2) + Math.pow(point.y - center.y, 2)) <= Math.pow(radius, 2);
+  return (Math.pow(point.x - center.x, 2) + Math.pow(point.y - center.y, 2)) <= Math.pow(radius + borderWidth, 2);
 }
 
 export function inBoxRange(mouseX, mouseY, {x, y, width, height}) {

--- a/src/types/point.js
+++ b/src/types/point.js
@@ -6,7 +6,7 @@ export default class PointAnnotation extends Element {
 
   inRange(mouseX, mouseY, useFinalPosition) {
     const {width} = this.getProps(['width'], useFinalPosition);
-    return inPointRange({x: mouseX, y: mouseY}, this.getCenterPoint(useFinalPosition), width / 2 + this.options.borderWidth);
+    return inPointRange({x: mouseX, y: mouseY}, this.getCenterPoint(useFinalPosition), width / 2, this.options.borderWidth);
   }
 
   getCenterPoint(useFinalPosition) {

--- a/test/specs/point.spec.js
+++ b/test/specs/point.spec.js
@@ -107,7 +107,7 @@ describe('Point annotation', function() {
                 xValue: 5,
                 yValue: 5,
                 radius: 0,
-                borderWidth: 0,
+                borderWidth: 5,
                 xAdjust: 0,
                 yAdjust: 0
               }
@@ -161,6 +161,98 @@ describe('Point annotation', function() {
 
       window.afterEvent(chart, 'click', function() {
         expect(clickSpy.calls.count()).toBe(0);
+        delete pointOpts.click;
+        done();
+      });
+      window.triggerMouseEvent(chart, 'click', eventPoint);
+    });
+
+  });
+
+  describe('events on point, triggered on borderWidth, ', function() {
+
+    const chartConfig = {
+      type: 'scatter',
+      options: {
+        animation: false,
+        scales: {
+          x: {
+            display: false,
+            min: 0,
+            max: 10
+          },
+          y: {
+            display: false,
+            min: 0,
+            max: 10
+          }
+        },
+        plugins: {
+          legend: false,
+          annotation: {
+            annotations: {
+              point: {
+                type: 'point',
+                id: 'test',
+                xScaleID: 'x',
+                yScaleID: 'y',
+                xValue: 5,
+                yValue: 5,
+                radius: 20,
+                borderWidth: 5,
+                xAdjust: 0,
+                yAdjust: 0
+              }
+            }
+          }
+        }
+      },
+    };
+
+    const pointOpts = chartConfig.options.plugins.annotation.annotations.point;
+
+    it('should detect enter and leave events on the point', function(done) {
+      const enterSpy = jasmine.createSpy('enter');
+      const leaveSpy = jasmine.createSpy('leave');
+
+      pointOpts.enter = enterSpy;
+      pointOpts.leave = leaveSpy;
+
+      const chart = window.acquireChart(chartConfig);
+      const xScale = chart.scales.x;
+      const yScale = chart.scales.y;
+      const eventPoint = {x: xScale.getPixelForValue(5) + pointOpts.radius + pointOpts.borderWidth / 2 - 1, y: yScale.getPixelForValue(5)};
+
+      window.triggerMouseEvent(chart, 'mousemove', eventPoint);
+      window.afterEvent(chart, 'mousemove', function() {
+        expect(enterSpy.calls.count()).toBe(1);
+
+        window.triggerMouseEvent(chart, 'mousemove', {
+          x: 0,
+          y: 0
+        });
+
+        window.afterEvent(chart, 'mousemove', function() {
+          expect(leaveSpy.calls.count()).toBe(1);
+          delete pointOpts.enter;
+          delete pointOpts.leave;
+          done();
+        });
+      });
+    });
+
+    it('should detect click event on the point', function(done) {
+      const clickSpy = jasmine.createSpy('click');
+
+      pointOpts.click = clickSpy;
+
+      const chart = window.acquireChart(chartConfig);
+      const xScale = chart.scales.x;
+      const yScale = chart.scales.y;
+      const eventPoint = {x: xScale.getPixelForValue(5) + pointOpts.radius + pointOpts.borderWidth / 2 - 1, y: yScale.getPixelForValue(5)};
+
+      window.afterEvent(chart, 'click', function() {
+        expect(clickSpy.calls.count()).toBe(1);
         delete pointOpts.click;
         done();
       });

--- a/test/specs/point.spec.js
+++ b/test/specs/point.spec.js
@@ -76,4 +76,96 @@ describe('Point annotation', function() {
       expect(createAndUpdateChart).not.toThrow();
     });
   });
+
+  describe('events on point with radius 0', function() {
+
+    const chartConfig = {
+      type: 'scatter',
+      options: {
+        animation: false,
+        scales: {
+          x: {
+            display: false,
+            min: 0,
+            max: 10
+          },
+          y: {
+            display: false,
+            min: 0,
+            max: 10
+          }
+        },
+        plugins: {
+          legend: false,
+          annotation: {
+            annotations: {
+              point: {
+                type: 'point',
+                id: 'test',
+                xScaleID: 'x',
+                yScaleID: 'y',
+                xValue: 5,
+                yValue: 5,
+                radius: 0,
+                borderWidth: 0,
+                xAdjust: 0,
+                yAdjust: 0
+              }
+            }
+          }
+        }
+      },
+    };
+
+    const pointOpts = chartConfig.options.plugins.annotation.annotations.point;
+
+    it('should not detect any enter and leave events on the point', function(done) {
+      const enterSpy = jasmine.createSpy('enter');
+      const leaveSpy = jasmine.createSpy('leave');
+
+      pointOpts.enter = enterSpy;
+      pointOpts.leave = leaveSpy;
+
+      const chart = window.acquireChart(chartConfig);
+      const xScale = chart.scales.x;
+      const yScale = chart.scales.y;
+      const eventPoint = {x: xScale.getPixelForValue(5), y: yScale.getPixelForValue(5)};
+
+      window.triggerMouseEvent(chart, 'mousemove', eventPoint);
+      window.afterEvent(chart, 'mousemove', function() {
+        expect(enterSpy.calls.count()).toBe(0);
+
+        window.triggerMouseEvent(chart, 'mousemove', {
+          x: 0,
+          y: 0
+        });
+
+        window.afterEvent(chart, 'mousemove', function() {
+          expect(leaveSpy.calls.count()).toBe(0);
+          delete pointOpts.enter;
+          delete pointOpts.leave;
+          done();
+        });
+      });
+    });
+
+    it('should not detect click event on the point', function(done) {
+      const clickSpy = jasmine.createSpy('click');
+
+      pointOpts.click = clickSpy;
+
+      const chart = window.acquireChart(chartConfig);
+      const xScale = chart.scales.x;
+      const yScale = chart.scales.y;
+      const eventPoint = {x: xScale.getPixelForValue(5), y: yScale.getPixelForValue(5)};
+
+      window.afterEvent(chart, 'click', function() {
+        expect(clickSpy.calls.count()).toBe(0);
+        delete pointOpts.click;
+        done();
+      });
+      window.triggerMouseEvent(chart, 'click', eventPoint);
+    });
+
+  });
 });


### PR DESCRIPTION
This PR is adding a specific test case in order to test `inRange` method when `radius` of the point annotation is 0.

Furthermore, it changes the invocation on `isPointRange`, passing radius and `borderWidth` separately. There was a case where the `radius` could be set to 0 and `borderWidth` to another figure and the `isPointRange` could return `true` (instead of `false`).