### PR TITLE
Remove `readValueToProps` function of options helpers

### DIFF
--- a/src/helpers/helpers.options.js
+++ b/src/helpers/helpers.options.js
@@ -37,20 +37,18 @@ export function calculateTextAlignment(size, options) {
   return x;
 }
 
-function readValueToProps(value, keys, defValue) {
-  const ret = {};
-  const read = isObject(value)
-    ? prop => value[prop]
-    : () => value;
-
-  for (const prop of keys) {
-    ret[prop] = valueOrDefault(read(prop), defValue);
-  }
-  return ret;
-}
-
 export function toPosition(value) {
-  return readValueToProps(value, ['x', 'y'], 'center');
+  if (isObject(value)) {
+    return {
+      x: valueOrDefault(value.x, 'center'),
+      y: valueOrDefault(value.y, 'center'),
+    };
+  }
+  value = valueOrDefault(value, 'center');
+  return {
+    x: value,
+    y: value
+  };
 }
 
 export function isBoundToPoint(options) {

--- a/src/helpers/helpers.options.js
+++ b/src/helpers/helpers.options.js
@@ -37,14 +37,10 @@ export function calculateTextAlignment(size, options) {
   return x;
 }
 
-function readValueToProps(value, props, defValue) {
+function readValueToProps(value, keys, defValue) {
   const ret = {};
-  const objProps = isObject(props);
-  const keys = objProps ? Object.keys(props) : props;
   const read = isObject(value)
-    ? objProps
-      ? prop => valueOrDefault(value[prop], value[props[prop]])
-      : prop => value[prop]
+    ? prop => value[prop]
     : () => value;
 
   for (const prop of keys) {


### PR DESCRIPTION
This PS is removing part of the code, currently not used because the function was taken by Chart.js (changing the default) but it had additional features not used in this plugin.