### PR TITLE
Normalize table headers and samples blocks sequence in the documentation

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -8,7 +8,7 @@ This plugin needs to be registered. It does not function as inline plugin.
 
 An annotation plugin for Chart.js >= 3.0.0
 
-This plugin draws lines, boxes, points and ellipses on the chart area. Annotations work with line, bar, scatter and bubble charts that use linear, logarithmic, time, or category scales. Annotations will not work on any chart that does not have exactly two axes, including pie, radar, and polar area charts.
+This plugin draws lines, boxes, labels, points, polygons and ellipses on the chart area. Annotations work with line, bar, scatter and bubble charts that use linear, logarithmic, time, or category scales. Annotations will not work on any chart that does not have exactly two axes, including pie, radar, and polar area charts.
 
 ![Banner](./banner.png)
 

--- a/docs/guide/types/box.md
+++ b/docs/guide/types/box.md
@@ -79,8 +79,8 @@ The following options are available for box annotations.
 
 If one of the axes does not match an axis in the chart, the box will take the entire chart dimension. The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the box is expanded out to the edges in the respective direction.
 
-| Name | Description |
-| ---- | ---- |
+| Name | Description
+| ---- | ----
 | `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
 | `display` | Whether or not this annotation is visible.
 | `drawTime` | See [drawTime](../options#draw-time).
@@ -93,8 +93,8 @@ If one of the axes does not match an axis in the chart, the box will take the en
 
 ### Styling
 
-| Name | Description |
-| ---- | ---- |
+| Name | Description
+| ---- | ----
 | `backgroundColor` | Fill color.
 | `backgroundShadowColor` | The color of shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
 | `borderCapStyle` | Cap style of the border line. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap).
@@ -120,7 +120,7 @@ Namespace: `options.annotations[annotationID].label`, it defines options for the
 All of these options can be [Scriptable](../options#scriptable-options)
 
 | Name | Type | Default | Notes
-| ---- | ---- | :----: | ---- | ----
+| ---- | ---- | :----: | ----
 | `color` | [`Color`](../options#color) | `'#fff'` | Text color.
 | `content` | `string`\|`string[]`\|[`Image`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image)\|[`HTMLCanvasElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement) | `null` | The content to show in the label.
 | `drawTime` | `string` | `options.drawTime` | See [drawTime](../options#draw-time). Defaults to the box annotation draw time if unset

--- a/docs/guide/types/ellipse.md
+++ b/docs/guide/types/ellipse.md
@@ -9,7 +9,7 @@ const options = {
     autocolors: false,
     annotation: {
       annotations: {
-        box1: {
+        ellipse1: {
           type: 'ellipse',
           xMin: 1,
           xMax: 2,
@@ -76,8 +76,8 @@ The following options are available for ellipse annotations.
 
 If one of the axes does not match an axis in the chart, the ellipse will take the entire chart dimension. The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the ellipse is expanded out to the edges in the respective direction.
 
-| Name | Description |
-| ---- | ---- |
+| Name | Description
+| ---- | ----
 | `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
 | `display` | Whether or not this annotation is visible.
 | `drawTime` | See [drawTime](../options#draw-time).
@@ -91,8 +91,8 @@ If one of the axes does not match an axis in the chart, the ellipse will take th
 
 ### Styling
 
-| Name | Description |
-| ---- | ---- |
+| Name | Description
+| ---- | ----
 | `backgroundColor` | Fill color.
 | `backgroundShadowColor` | The color of shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
 | `borderColor` | Stroke color.

--- a/docs/guide/types/label.md
+++ b/docs/guide/types/label.md
@@ -96,8 +96,8 @@ If one of the axes does not match an axis in the chart, the content will be rend
 The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the box is expanded out to the edges in the respective direction and the box size is used to calculated the center of the point. To enable to use the box positioning, the `radius` must be set to `0` or `NaN`.
 
 
-| Name | Description |
-| ---- | ---- |
+| Name | Description
+| ---- | ----
 | `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
 | `content` | The content to show in the text annotation.
 | `display` | Whether or not this annotation is visible.
@@ -119,8 +119,8 @@ The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the bo
 
 ### Styling
 
-| Name | Description |
-| ---- | ---- |
+| Name | Description
+| ---- | ----
 | `backgroundColor` | Fill color.
 | `backgroundShadowColor` | The color of shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
 | `borderCapStyle` | Cap style of the border line. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap).
@@ -212,7 +212,7 @@ module.exports = {
 All of these options can be [Scriptable](../options#scriptable-options).
 
 | Name | Type | Default | Notes
-| ---- | ---- | :----: | ---- | ----
+| ---- | ---- | :----: | ----
 | `borderCapStyle` | `string` | `'butt'` | Cap style of the border line of callout. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap).
 | `borderColor` | [`Color`](../options#color) | `undefined` | Stroke color of the pointer of the callout.
 | `borderDash` | `number[]` | `[]` | Length and spacing of dashes of callout. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash).

--- a/docs/guide/types/line.md
+++ b/docs/guide/types/line.md
@@ -49,7 +49,7 @@ module.exports = {
 The following options are available for line annotations. All of these options can be .
 
 | Name | Type | [Scriptable](../options#scriptable-options) | Default
-| ---- | ---- | ---- | :----: | ----
+| ---- | ---- | :----: | ----
 | [`adjustScaleRange`](#general) | `boolean` | Yes | `true`
 | [`borderColor`](#styling) | [`Color`](../options#color) | Yes | `options.color`
 | [`borderDash`](#styling) | `number[]` | Yes | `[]`
@@ -83,8 +83,8 @@ If one of the axes does not match an axis in the chart and the line behaviors ar
 The 2 coordinates, start, end, are optional. If not specified, the line is expanded out to the edges in the respective direction.
 The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the line is expanded out to the edges in the respective direction.
 
-| Name | Description |
-| ---- | ---- |
+| Name | Description
+| ---- | ----
 | `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
 | `display` | Whether or not this annotation is visible.
 | `drawTime` | See [drawTime](../options#draw-time).
@@ -95,8 +95,8 @@ The line can be positioned in two different ways. If `scaleID` is set, then `val
 
 If `scaleID` is unset, then `xScaleID` and `yScaleID` are used to draw a line from `(xMin, yMin)` to `(xMax, yMax)`.
 
-| Name | Description |
-| ---- | ---- |
+| Name | Description
+| ---- | ----
 | `endValue` | End two of the line when a single scale is specified.
 | `scaleID` | ID of the scale in single scale mode. If unset, `xScaleID` and `yScaleID` are used.
 | `value` | End one of the line when a single scale is specified.
@@ -109,8 +109,8 @@ If `scaleID` is unset, then `xScaleID` and `yScaleID` are used to draw a line fr
 
 ### Styling
 
-| Name | Description |
-| ---- | ---- |
+| Name | Description
+| ---- | ----
 | `borderColor` | Stroke color.
 | `borderDash` | Length and spacing of dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash).
 | `borderDashOffset` | Offset for line dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset).
@@ -127,7 +127,7 @@ Namespace: `options.annotations[annotationID].label`, it defines options for the
 All of these options can be [Scriptable](../options#scriptable-options)
 
 | Name | Type | Default | Notes
-| ---- | ---- | :----: | ---- | ----
+| ---- | ---- | :----: | ----
 | `backgroundColor` | [`Color`](../options#color) | `'rgba(0,0,0,0.8)'` | Background color of the label container.
 | `backgroundShadowColor` | [`Color`](../options#color) | `'transparent'` | The color of shadow of the box where the label is located. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
 | `borderCapStyle` | `string` | `'butt'` | Cap style of the border line. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap).

--- a/docs/guide/types/point.md
+++ b/docs/guide/types/point.md
@@ -83,8 +83,8 @@ If one of the axes does not match an axis in the chart, the point annotation wil
 The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the box is expanded out to the edges in the respective direction and the box size is used to calculated the center of the point. To enable to use the box positioning, the `radius` must be set to `0` or `NaN`. 
 
 
-| Name | Description |
-| ---- | ---- |
+| Name | Description
+| ---- | ----
 | `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
 | `display` | Whether or not this annotation is visible.
 | `drawTime` | See [drawTime](../options#draw-time).
@@ -103,8 +103,8 @@ The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the bo
 
 ### Styling
 
-| Name | Description |
-| ---- | ---- |
+| Name | Description
+| ---- | ----
 | `backgroundColor` | Fill color.
 | `backgroundShadowColor` | The color of shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
 | `borderColor` | Stroke color.

--- a/docs/guide/types/polygon.md
+++ b/docs/guide/types/polygon.md
@@ -86,8 +86,8 @@ If one of the axes does not match an axis in the chart, the polygon annotation w
 
 The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the box is expanded out to the edges in the respective direction and the box size is used to calculated the center of the point. To enable to use the box positioning, the `radius` must be set to `0` or `NaN`. 
 
-| Name | Description |
-| ---- | ---- |
+| Name | Description
+| ---- | ----
 | `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
 | `display` | Whether or not this annotation is visible.
 | `drawTime` | See [drawTime](../options#draw-time).
@@ -107,8 +107,8 @@ The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the bo
 
 ### Styling
 
-| Name | Description |
-| ---- | ---- |
+| Name | Description
+| ---- | ----
 | `backgroundColor` | Fill color.
 | `backgroundShadowColor` | The color of shadow. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
 | `borderColor` | Stroke color.

--- a/docs/samples/box/disclosure.md
+++ b/docs/samples/box/disclosure.md
@@ -1,7 +1,7 @@
 # Disclosure
 
 ```js chart-editor
-// <block:setup:5>
+// <block:setup:2>
 const DATA_COUNT = 12;
 const MIN = 10;
 const MAX = 100;

--- a/docs/samples/charts/bar.md
+++ b/docs/samples/charts/bar.md
@@ -1,7 +1,7 @@
 # Bar Chart
 
 ```js chart-editor
-// <block:setup:5>
+// <block:setup:4>
 const DATA_COUNT = 8;
 const MIN = 10;
 const MAX = 100;

--- a/docs/samples/charts/line.md
+++ b/docs/samples/charts/line.md
@@ -1,13 +1,12 @@
 # Line Chart
 
 ```js chart-editor
-// <block:setup:5>
+// <block:setup:4>
 const DATA_COUNT = 8;
 const MIN = 10;
 const MAX = 100;
 
 Utils.srand(8);
-
 
 const numberCfg = {count: DATA_COUNT, min: MIN, max: MAX};
 

--- a/docs/samples/ellipse/basic.md
+++ b/docs/samples/ellipse/basic.md
@@ -70,7 +70,6 @@ function max(ctx, datasetIndex, prop) {
   const dataset = ctx.chart.data.datasets[datasetIndex];
   return dataset.data.reduce((v, point) => Math.max(point[prop], v), -Infinity);
 }
-
 // </block:utils>
 
 const actions = [

--- a/docs/samples/ellipse/rotation.md
+++ b/docs/samples/ellipse/rotation.md
@@ -84,7 +84,6 @@ function max(ctx, datasetIndex, prop) {
   const dataset = ctx.chart.data.datasets[datasetIndex];
   return dataset.data.reduce((v, point) => Math.max(point[prop], v), -Infinity);
 }
-
 // </block:utils>
 
 const actions = [

--- a/docs/samples/label/basic.md
+++ b/docs/samples/label/basic.md
@@ -1,7 +1,7 @@
 # Basic
 
 ```js chart-editor
-// <block:setup:4>
+// <block:setup:5>
 const DATA_COUNT = 12;
 const MIN = 0;
 const MAX = 100;
@@ -94,7 +94,7 @@ const config = {
 };
 /* </block:config> */
 
-// <block:utils:5>
+// <block:utils:4>
 function yValue(ctx, label) {
   const chart = ctx.chart;
   const dataset = chart.data.datasets[0];

--- a/docs/samples/label/callout.md
+++ b/docs/samples/label/callout.md
@@ -1,7 +1,7 @@
 # Callout
 
 ```js chart-editor
-// <block:setup:2>
+// <block:setup:3>
 const DATA_COUNT = 12;
 const MIN = 0;
 const MAX = 100;
@@ -62,7 +62,7 @@ const config = {
 };
 /* </block:config> */
 
-// <block:utils:3>
+// <block:utils:2>
 function maxValue(ctx) {
   const values = ctx.chart.data.datasets[0].data;
   return Math.max(...values);

--- a/docs/samples/label/lowerUpper.md
+++ b/docs/samples/label/lowerUpper.md
@@ -1,7 +1,7 @@
 # Lower and upper bounds labels
 
 ```js chart-editor
-// <block:setup:3>
+// <block:setup:4>
 const DATA_COUNT = 8;
 const MIN = 10;
 const MAX = 100;
@@ -79,7 +79,7 @@ const config = {
 };
 /* </block:config> */
 
-// <block:utils:4>
+// <block:utils:3>
 function minValue(ctx) {
   const dataset = ctx.chart.data.datasets[0];
   const min = dataset.data.reduce((max, point) => Math.min(point, max), Infinity);

--- a/docs/samples/label/point.md
+++ b/docs/samples/label/point.md
@@ -1,7 +1,7 @@
 # Point
 
 ```js chart-editor
-// <block:setup:3>
+// <block:setup:4>
 const DATA_COUNT = 12;
 const MIN = 0;
 const MAX = 100;
@@ -82,7 +82,7 @@ const config = {
 };
 /* </block:config> */
 
-// <block:utils:4>
+// <block:utils:3>
 function maxValue(ctx) {
   let max = 0;
   const dataset = ctx.chart.data.datasets[0];

--- a/docs/samples/line/animation.md
+++ b/docs/samples/line/animation.md
@@ -3,7 +3,7 @@
 <input id="update" type="range" style="width:100%"/>
 
 ```js chart-editor
-// <block:setup:2>
+// <block:setup:3>
 const uniqueId = new Date().getTime();
 
 const data = {
@@ -56,7 +56,7 @@ const config = {
 };
 /* </block:config> */
 
-// <block:utils:3>
+// <block:utils:2>
 document.getElementById('update').addEventListener('input', update);
 
 function update() {

--- a/docs/samples/line/average.md
+++ b/docs/samples/line/average.md
@@ -1,7 +1,7 @@
 # Average
 
 ```js chart-editor
-// <block:setup:2>
+// <block:setup:3>
 const DATA_COUNT = 8;
 const MIN = 10;
 const MAX = 100;
@@ -56,7 +56,7 @@ const config = {
 };
 /* </block:config> */
 
-// <block:utils:3>
+// <block:utils:2>
 function average(ctx) {
   const values = ctx.chart.data.datasets[0].data;
   return values.reduce((a, b) => a + b, 0) / values.length;

--- a/docs/samples/line/basic.md
+++ b/docs/samples/line/basic.md
@@ -1,7 +1,7 @@
 # Basic
 
 ```js chart-editor
-// <block:setup:4>
+// <block:setup:2>
 const DATA_COUNT = 8;
 const MIN = 10;
 const MAX = 100;

--- a/docs/samples/line/datasetBars.md
+++ b/docs/samples/line/datasetBars.md
@@ -1,7 +1,7 @@
 # Annotating dataset bars 
 
 ```js chart-editor
-// <block:setup:5>
+// <block:setup:6>
 const DATA_COUNT = 4;
 const MIN = 20;
 const MAX = 100;
@@ -102,7 +102,26 @@ const annotation4 = {
 };
 // </block:annotation4>
 
-// <block:utils:6>
+/* <block:config:0> */
+const config = {
+  type: 'bar',
+  data,
+  options: {
+    plugins: {
+      annotation: {
+        annotations: {
+          annotation1,
+          annotation2,
+          annotation3,
+          annotation4
+        }
+      }
+    }
+  }
+};
+/* </block:config> */
+
+// <block:utils:5>
 // categoryPercentage is 0.8 by default
 // barPercentage is 0.9 by default
 // 1 * 0.8 * 0.9 = 0.72
@@ -122,25 +141,6 @@ function middleValue(ctx, index, perc) {
   return dataset.data[index] * perc;
 }
 // </block:utils>
-
-/* <block:config:0> */
-const config = {
-  type: 'bar',
-  data,
-  options: {
-    plugins: {
-      annotation: {
-        annotations: {
-          annotation1,
-          annotation2,
-          annotation3,
-          annotation4
-        }
-      }
-    }
-  }
-};
-/* </block:config> */
 
 const actions = [
   {

--- a/docs/samples/line/labelVisibility.md
+++ b/docs/samples/line/labelVisibility.md
@@ -1,7 +1,7 @@
 # Label visibility
 
 ```js chart-editor
-// <block:setup:3>
+// <block:setup:4>
 const DATA_COUNT = 8;
 const MIN = 10;
 const MAX = 100;
@@ -99,11 +99,12 @@ const config = {
 };
 /* </block:config> */
 
-// <block:utils:4>
+// <block:utils:3>
 function average(ctx) {
   const values = ctx.chart.data.datasets[0].data;
   return values.reduce((a, b) => a + b, 0) / values.length;
 }
+
 function min(ctx) {
   const values = ctx.chart.data.datasets[0].data;
   return values.reduce((a, b) => Math.min(a, b), Infinity);

--- a/docs/samples/line/standardDeviation.md
+++ b/docs/samples/line/standardDeviation.md
@@ -1,7 +1,7 @@
 # Standard deviation
 
 ```js chart-editor
-// <block:setup:4>
+// <block:setup:5>
 const DATA_COUNT = 16;
 const MIN = 10;
 const MAX = 100;
@@ -107,7 +107,7 @@ const config = {
 };
 /* </block:config> */
 
-// <block:utils:5>
+// <block:utils:4>
 function average(ctx) {
   const values = ctx.chart.data.datasets[0].data;
   return values.reduce((a, b) => a + b, 0) / values.length;

--- a/docs/samples/point/basic.md
+++ b/docs/samples/point/basic.md
@@ -1,7 +1,7 @@
 # Basic
 
 ```js chart-editor
-// <block:setup:4>
+// <block:setup:5>
 const DATA_COUNT = 8;
 const MIN = 10;
 const MAX = 100;
@@ -85,7 +85,7 @@ const config = {
 };
 /* </block:config> */
 
-// <block:utils:3>
+// <block:utils:4>
 function value(ctx, datasetIndex, index, prop) {
   const meta = ctx.chart.getDatasetMeta(datasetIndex);
   const parsed = meta.controller.getParsed(index);

--- a/docs/samples/point/outsideChartArea.md
+++ b/docs/samples/point/outsideChartArea.md
@@ -1,7 +1,7 @@
 # Points outside of chart area
 
 ```js chart-editor
-// <block:setup:6>
+// <block:setup:3>
 const DATA_COUNT = 12;
 const MIN = 10;
 const MAX = 100;

--- a/docs/samples/point/shadow.md
+++ b/docs/samples/point/shadow.md
@@ -1,7 +1,7 @@
 # Shadow
 
 ```js chart-editor
-// <block:setup:4>
+// <block:setup:5>
 const DATA_COUNT = 8;
 const MIN = 10;
 const MAX = 100;
@@ -97,7 +97,7 @@ const config = {
 };
 /* </block:config> */
 
-// <block:utils:3>
+// <block:utils:4>
 function value(ctx, datasetIndex, index, prop) {
   const meta = ctx.chart.getDatasetMeta(datasetIndex);
   const parsed = meta.controller.getParsed(index);

--- a/docs/samples/polygon/basic.md
+++ b/docs/samples/polygon/basic.md
@@ -1,7 +1,7 @@
 # Basic
 
 ```js chart-editor
-// <block:setup:4>
+// <block:setup:5>
 const DATA_COUNT = 8;
 const MIN = 10;
 const MAX = 100;
@@ -86,7 +86,7 @@ const config = {
 };
 /* </block:config> */
 
-// <block:utils:5>
+// <block:utils:4>
 function value(ctx, datasetIndex, index, prop) {
   const meta = ctx.chart.getDatasetMeta(datasetIndex);
   const parsed = meta.controller.getParsed(index);

--- a/docs/samples/polygon/shadow.md
+++ b/docs/samples/polygon/shadow.md
@@ -1,7 +1,7 @@
 # Shadow
 
 ```js chart-editor
-// <block:setup:6>
+// <block:setup:7>
 const DATA_COUNT = 8;
 const MIN = 10;
 const MAX = 100;
@@ -75,7 +75,7 @@ const annotation3 = {
   xValue: (ctx) => value(ctx, 0, 4, 'x'),
   yValue: (ctx) => value(ctx, 0, 4, 'y')
 };
-// </block:annotation5>
+// </block:annotation3>
 
 // <block:annotation4:4>
 const annotation4 = {
@@ -135,7 +135,7 @@ const config = {
 };
 /* </block:config> */
 
-// <block:utils:7>
+// <block:utils:6>
 function value(ctx, datasetIndex, index, prop) {
   const meta = ctx.chart.getDatasetMeta(datasetIndex);
   const parsed = meta.controller.getParsed(index);

--- a/docs/samples/polygon/stop.md
+++ b/docs/samples/polygon/stop.md
@@ -1,7 +1,7 @@
 # Stop
 
 ```js chart-editor
-// <block:setup:6>
+// <block:setup:7>
 const DATA_COUNT = 8;
 const MIN = 10;
 const MAX = 100;
@@ -67,7 +67,7 @@ const annotation3 = {
   xValue: (ctx) => value(ctx, 0, 4, 'x'),
   yValue: (ctx) => value(ctx, 0, 4, 'y')
 };
-// </block:annotation5>
+// </block:annotation3>
 
 // <block:annotation4:4>
 const annotation4 = {
@@ -123,7 +123,7 @@ const config = {
 };
 /* </block:config> */
 
-// <block:utils:7>
+// <block:utils:6>
 function value(ctx, datasetIndex, index, prop) {
   const meta = ctx.chart.getDatasetMeta(datasetIndex);
   const parsed = meta.controller.getParsed(index);


### PR DESCRIPTION
Fixes some table headers on the documentation,
Furthermore normalizes the blocks sequence in the samples as following:

`config`, `annotations`, `utils`, `setup`