### PR TITLE
Move label drawTime default to line annotation defaults

### DIFF
--- a/src/annotation.js
+++ b/src/annotation.js
@@ -111,10 +111,7 @@ export default {
     },
     clip: true,
     dblClickSpeed: 350, // ms
-    drawTime: 'afterDatasetsDraw',
-    label: {
-      drawTime: null
-    }
+    drawTime: 'afterDatasetsDraw'
   },
 
   descriptors: {

--- a/src/types/line.js
+++ b/src/types/line.js
@@ -213,7 +213,7 @@ LineAnnotation.defaults = {
     color: '#fff',
     content: null,
     cornerRadius: undefined, // TODO: v2 remove support for cornerRadius
-    drawTime: undefined,
+    drawTime: null,
     enabled: false,
     font: {
       family: undefined,


### PR DESCRIPTION
Fix #625

Not sure why the label `drawTime` was present in the annotations node. Maybe there are other reasons.