### PR TITLE
Fix the default options values in the documentation

### DIFF
--- a/docs/guide/types/box.md
+++ b/docs/guide/types/box.md
@@ -121,7 +121,7 @@ All of these options can be [Scriptable](../options#scriptable-options)
 
 | Name | Type | Default | Notes
 | ---- | ---- | :----: | ----
-| `color` | [`Color`](../options#color) | `'#fff'` | Text color.
+| `color` | [`Color`](../options#color) | `'black'` | Text color.
 | `content` | `string`\|`string[]`\|[`Image`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image)\|[`HTMLCanvasElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement) | `null` | The content to show in the label.
 | `drawTime` | `string` | `options.drawTime` | See [drawTime](../options#draw-time). Defaults to the box annotation draw time if unset
 | `enabled` | `boolean` | `false` | Whether or not the label is shown.
@@ -129,7 +129,7 @@ All of these options can be [Scriptable](../options#scriptable-options)
 | `height` | `number`\|`string` | `undefined` | Overrides the height of the image or canvas element. Could be set in pixel by a number, or in percentage of current height of image or canvas element by a string. If undefined, uses the height of the image or canvas element. It is used only when the content is an image or canvas element.
 | `padding` | [`Padding`](../options#padding) | `6` | The padding to add around the text label.
 | [`position`](#position) | `string`\|`{x: string, y: string}` | `'center'` | Anchor position of label in the box.
-| `textAlign` | `string` | `'center'` | Text alignment of label content when there's more than one line. Possible options are: `'left'`, `'start'`, `'center'`, `'end'`, `'right'`.
+| `textAlign` | `string` | `'start'` | Text alignment of label content when there's more than one line. Possible options are: `'left'`, `'start'`, `'center'`, `'end'`, `'right'`.
 | `width` | `number`\|`string` | `undefined` | Overrides the width of the image or canvas element. Could be set in pixel by a number, or in percentage of current width of image or canvas element by a string. If undefined, uses the width of the image or canvas element. It is used only when the content is an image or canvas element.
 | `xAdjust` | `number` | `0` | Adjustment along x-axis (left-right) of label relative to computed position. Negative values move the label left, positive right.
 | `yAdjust` | `number` | `0` | Adjustment along y-axis (top-bottom) of label relative to computed position. Negative values move the label up, positive down.

--- a/docs/guide/types/line.md
+++ b/docs/guide/types/line.md
@@ -55,7 +55,7 @@ The following options are available for line annotations. All of these options c
 | [`borderDash`](#styling) | `number[]` | Yes | `[]`
 | [`borderDashOffset`](#styling) | `number` | Yes | `0`
 | [`borderShadowColor`](#styling) | [`Color`](../options#color) | Yes | `'transparent'`
-| [`borderWidth`](#styling) | `number` | Yes | `1`
+| [`borderWidth`](#styling) | `number` | Yes | `2`
 | [`display`](#general) | `boolean` | Yes | `true`
 | [`drawTime`](#general) | `string` | Yes | `'afterDatasetsDraw'`
 | [`endValue`](#positioning) | `number` | Yes | `undefined`
@@ -142,7 +142,7 @@ All of these options can be [Scriptable](../options#scriptable-options)
 | `content` | `string`\|`string[]`\|[`Image`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image)\|[`HTMLCanvasElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement) | `null` | The content to show in the label.
 | `drawTime` | `string` | `options.drawTime` | See [drawTime](../options#draw-time). Defaults to the line annotation draw time if unset.
 | `enabled` | `boolean` | `false` | Whether or not the label is shown.
-| `font` | [`Font`](../options#font) | `{ style: 'bold' }` | Label font.
+| `font` | [`Font`](../options#font) | `{ weight: 'bold' }` | Label font.
 | `height` | `number`\|`string` | `undefined` | Overrides the height of the image or canvas element. Could be set in pixel by a number, or in percentage of current height of image or canvas element by a string. If undefined, uses the height of the image or canvas element. It is used only when the content is an image or canvas element.
 | `padding` | [`Padding`](../options#padding) | `6` | The padding to add around the text label.
 | `position` | `string` | `'center'` | Anchor position of label on line. Possible options are: `'start'`, `'center'`, `'end'`. It can be set by a string in percentage format `'number%'` which are representing the percentage on the width of the line where the label will be located.


### PR DESCRIPTION
Fix the default values of the line and box options where they were wrong.