### PR TITLE
Workaround for annotation option resolution

### DIFF
--- a/test/specs/annotation.spec.js
+++ b/test/specs/annotation.spec.js
@@ -38,4 +38,76 @@ describe('Annotation plugin', function() {
 
     console.warn = origWarn;
   });
+
+  describe('Annotation option resolution', function() {
+    it('should resolve from plugin options', function() {
+      const chart = acquireChart({
+        type: 'line',
+        options: {
+          plugins: {
+            annotation: {
+              drawTime: 'fallback',
+              annotations: {
+                test: {
+                  type: 'line'
+                }
+              }
+            }
+          }
+        }
+      });
+      const state = window['chartjs-plugin-annotation']._getState(chart);
+      const element = state.elements[0];
+      expect(element.options.drawTime).toBe('fallback');
+    });
+
+    it('should not resolve from same sub key in plugin options', function() {
+      // https://github.com/chartjs/chartjs-plugin-annotation/issues/625
+      // https://github.com/chartjs/chartjs-plugin-annotation/pull/626#issuecomment-1012960850
+      const chart = acquireChart({
+        type: 'line',
+        options: {
+          plugins: {
+            annotation: {
+              test: {
+                drawTime: 'invalid'
+              },
+              annotations: {
+                test: {
+                  type: 'line'
+                }
+              }
+            }
+          }
+        }
+      });
+      const state = window['chartjs-plugin-annotation']._getState(chart);
+      const element = state.elements[0];
+      expect(element.options.drawTime).not.toBe('invalid');
+    });
+
+    // TODO: enable when desired option resolution can be configured in chart.js
+    xit('should resolve to same options through chart options', function() {
+      const chart = acquireChart({
+        type: 'line',
+        options: {
+          plugins: {
+            annotation: {
+              test: {
+                drawTime: 'invalid'
+              },
+              annotations: {
+                test: {
+                  type: 'line'
+                }
+              }
+            }
+          }
+        }
+      });
+      const state = window['chartjs-plugin-annotation']._getState(chart);
+      const element = state.elements[0];
+      expect(element.options.drawTime).toBe(chart.options.plugins.annotation.annotations.test.drawTime);
+    });
+  });
 });


### PR DESCRIPTION
Fix: #625

This fixes the issue, but leaves the resolution inconsistent (`chart.options.plugins.annotation.annotations[id].someOption` might resolve to different value than the `element.options.someOption`). This only happens in these rare cases though, where annotation id matches a key in `options.plugins.annotation` or `defaults.plugins.annotation`.

Maybe another solution is to change the current fallback of `plugin.annotation` to something else (for example `plugin.annotation.annotationDefaults` or removing it entirely and duplicating the common options in every element (as it mostly actually is now).

I'm not entirely happy with this yet, so will create as draft.