### PR TITLE
Box: change event tests to inRange tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 import {acquireChart, addMatchers, releaseCharts, specsFromFixtures, triggerMouseEvent, afterEvent} from 'chartjs-test-utils';
 import {testEvents} from './events';
-import {createCanvas} from './utils';
+import {createCanvas, scatter10x10} from './utils';
 
 window.devicePixelRatio = 1;
 window.acquireChart = acquireChart;
@@ -8,6 +8,7 @@ window.afterEvent = afterEvent;
 window.triggerMouseEvent = triggerMouseEvent;
 window.testEvents = testEvents;
 window.createCanvas = createCanvas;
+window.scatter10x10 = scatter10x10;
 
 jasmine.fixtures = specsFromFixtures;
 

--- a/test/specs/box.spec.js
+++ b/test/specs/box.spec.js
@@ -1,6 +1,44 @@
 describe('Box annotation', function() {
   describe('auto', jasmine.fixtures('box'));
 
+  describe('inRange', function() {
+    const annotation = {
+      type: 'box',
+      xScaleID: 'x',
+      yScaleID: 'y',
+      xMin: 2,
+      yMin: 4,
+      xMax: 8,
+      yMax: 6,
+      borderWidth: 0,
+      rotation: 0
+    };
+
+    const chart = window.scatter10x10({box: annotation});
+    const element = window['chartjs-plugin-annotation']._getState(chart).elements[0];
+
+    it('should return true inside element', function() {
+      for (const x of [element.x, element.x + element.width / 2, element.x + element.width]) {
+        for (const y of [element.y, element.y + element.height / 2, element.y + element.height]) {
+          expect(element.inRange(x, y)).toEqual(true);
+        }
+      }
+    });
+
+    it('should return false outside element', function() {
+      for (const x of [element.x - 1, element.x + element.width + 1]) {
+        for (const y of [element.y, element.y + element.height / 2, element.y + element.height]) {
+          expect(element.inRange(x, y)).toEqual(false);
+        }
+      }
+      for (const x of [element.x, element.x + element.width / 2, element.x + element.width]) {
+        for (const y of [element.y - 1, element.y + element.height + 1]) {
+          expect(element.inRange(x, y)).toEqual(false);
+        }
+      }
+    });
+  });
+
   const eventIn = function(xScale, yScale, element) {
     const options = element.options;
     const adjust = options.borderWidth / 2 - 1;
@@ -88,6 +126,5 @@ describe('Box annotation', function() {
       });
       window.triggerMouseEvent(chart, 'click', eventPoint);
     });
-
   });
 });

--- a/test/specs/box.spec.js
+++ b/test/specs/box.spec.js
@@ -4,8 +4,6 @@ describe('Box annotation', function() {
   describe('inRange', function() {
     const annotation = {
       type: 'box',
-      xScaleID: 'x',
-      yScaleID: 'y',
       xMin: 2,
       yMin: 4,
       xMax: 8,

--- a/test/utils.js
+++ b/test/utils.js
@@ -14,3 +14,30 @@ export function createCanvas() {
   ctx.stroke();
   return canvas;
 }
+
+export function scatter10x10(annotations) {
+  return window.acquireChart({
+    type: 'scatter',
+    options: {
+      animation: false,
+      scales: {
+        x: {
+          display: false,
+          min: 0,
+          max: 10
+        },
+        y: {
+          display: false,
+          min: 0,
+          max: 10
+        }
+      },
+      plugins: {
+        legend: false,
+        annotation: {
+          annotations
+        }
+      }
+    }
+  });
+}


### PR DESCRIPTION
Essentially test the thing directly, instead of creating a chart and firing events and stuff. Coverage is the same, but some lines get less throughput:

![image](https://user-images.githubusercontent.com/27971921/149758719-5065a209-683d-4fa0-932e-4fb8481a048b.png)
