### PR TITLE
Remove not used default route for backgroundColor option in label annotation

### DIFF
--- a/src/types/label.js
+++ b/src/types/label.js
@@ -105,8 +105,7 @@ LabelAnnotation.defaults = {
 };
 
 LabelAnnotation.defaultRoutes = {
-  borderColor: 'color',
-  backgroundColor: 'color',
+  borderColor: 'color'
 };
 
 function measureRect(point, size, options, padding) {


### PR DESCRIPTION
This PR remove not used default route for `backgroundColor` option in label annotation