### PR TITLE
Polygon: change event tests to inRange tests

### DIFF
--- a/src/types/polygon.js
+++ b/src/types/polygon.js
@@ -4,7 +4,7 @@ import {setBorderStyle, resolvePointPosition, getElementCenterPoint, setShadowSt
 
 export default class PolygonAnnotation extends Element {
   inRange(mouseX, mouseY, useFinalPosition) {
-    return this.elements.length > 1 && pointIsInPolygon(this.elements, mouseX, mouseY, useFinalPosition);
+    return this.options.radius >= 0.1 && this.elements.length > 1 && pointIsInPolygon(this.elements, mouseX, mouseY, useFinalPosition);
   }
 
   getCenterPoint(useFinalPosition) {

--- a/test/specs/polygon.spec.js
+++ b/test/specs/polygon.spec.js
@@ -1,91 +1,94 @@
 describe('Polygon annotation', function() {
   describe('auto', jasmine.fixtures('polygon'));
 
-  const eventIn = function(xScale, yScale, element) {
-    const options = element.options;
-    const adjust = options.borderWidth / 2 - 1;
-    return {x: element.x, y: element.y - element.height / 2 - adjust};
-  };
-  const eventOut = function(xScale, yScale, element) {
-    const options = element.options;
-    const adjust = options.borderWidth / 2 + 1;
-    return {x: element.x, y: element.y - element.height / 2 - adjust};
-  };
+  describe('inRange', function() {
+    const annotation1 = {
+      type: 'polygon',
+      xValue: 7,
+      yValue: 7,
+      radius: 30
+    };
+    const annotation2 = {
+      type: 'polygon',
+      xValue: 3,
+      yValue: 3,
+      radius: 0
+    };
+    const annotation3 = {
+      type: 'polygon',
+      xValue: 5,
+      yValue: 5,
+      radius: 0
+    };
 
-  window.testEvents({
-    type: 'polygon',
-    id: 'test',
-    xValue: 5,
-    yValue: 5,
-    rotation: 0,
-    radius: 30
-  }, eventIn, eventOut);
+    const chart = window.scatter10x10({annotation1, annotation2, annotation3});
+    const elems = window.getAnnotationElements(chart).filter(el => el.options.radius > 0);
+    const elemsNoRad = window.getAnnotationElements(chart).filter(el => el.options.radius === 0);
 
-  describe('events, removing borderWidth by callback, ', function() {
-    const chartConfig = {
-      type: 'scatter',
-      options: {
-        animation: false,
-        scales: {
-          x: {
-            display: false,
-            min: 0,
-            max: 10
-          },
-          y: {
-            display: false,
-            min: 0,
-            max: 10
-          }
-        },
-        plugins: {
-          legend: false,
-          annotation: {
-            annotations: {
-              polygon: {
-                type: 'polygon',
-                xValue: 5,
-                yValue: 5,
-                radius: 20,
-                borderWidth: 10
-              }
+    elems.forEach(function(element) {
+      it(`should return true inside element '${element.options.id}'`, function() {
+        const rotation = element.options.rotation;
+        for (let sides = 4; sides <= 4; sides++) {
+          element.options.sides = sides;
+          for (const borderWidth of [0]) {
+            const halfBorder = borderWidth / 2;
+            element.options.borderWidth = borderWidth;
+            const radius = element.height / 2;
+            const angle = (2 * Math.PI) / sides;
+            const vertices = [];
+            let rad = rotation * (Math.PI / 180);
+            for (let i = 0; i < sides; i++, rad += angle) {
+              const sin = Math.sin(rad);
+              const cos = Math.cos(rad);
+              vertices.push({
+                x: element.x + sin * (radius + halfBorder - 1),
+                y: element.y - cos * (radius + halfBorder - 1)
+              });
+            }
+            for (const vertex of vertices) {
+              //console.log('sides: '+ sides + ' borderWidth: ' + borderWidth + ' in: ' + element.inRange(vertex.x, vertex.y));
+              console.log({x: vertex.x, y: vertex.y}, {x: element.x, y: element.y, radius}, element.inRange(vertex.x, vertex.y));
+              //expect(element.inRange(vertex.x, vertex.y)).withContext(`sides: ${sides}, rotation: ${rotation}, radius: ${radius}, borderWidth: ${borderWidth}, {x: ${vertex.x.toFixed(1)}, y: ${vertex.y.toFixed(1)}}`).toEqual(true);
             }
           }
         }
-      },
-    };
-
-    const polygonOpts = chartConfig.options.plugins.annotation.annotations.polygon;
-
-    it('should detect click event', function(done) {
-      const clickSpy = jasmine.createSpy('click');
-
-      polygonOpts.click = function(ctx) {
-        if (ctx.element.options.borderWidth) {
-          delete ctx.element.options.borderWidth;
-          ctx.chart.draw();
-        } else {
-          ctx.element.options.click = clickSpy;
-        }
-      };
-
-      const chart = window.acquireChart(chartConfig);
-      const xScale = chart.scales.x;
-      const yScale = chart.scales.y;
-      const eventPoint = {x: xScale.getPixelForValue(5), y: yScale.getPixelForValue(5)};
-
-      window.afterEvent(chart, 'click', function() {
-        expect(clickSpy.calls.count()).toBe(0);
-
-        window.afterEvent(chart, 'click', function() {
-          expect(clickSpy.calls.count()).toBe(1);
-          delete polygonOpts.click;
-          done();
-        });
-        window.triggerMouseEvent(chart, 'click', eventPoint);
       });
-      window.triggerMouseEvent(chart, 'click', eventPoint);
-    });
+/*
 
+
+      it(`should return false outside element '${element.options.id}'`, function() {
+        for (const borderWidth of [0, 10]) {
+          const halfBorder = borderWidth / 2;
+          element.options.borderWidth = borderWidth;
+          const radius = element.height / 2;
+          for (const angle of [0, 45, 90, 135, 180, 225, 270, 315]) {
+            const rad = angle * (Math.PI / 180);
+            const {x, y} = {
+              x: element.x + Math.cos(rad) * (radius + halfBorder + 1),
+              y: element.y + Math.sin(rad) * (radius + halfBorder + 1)
+            };
+            expect(element.inRange(x, y)).withContext(`angle: ${angle}, radius: ${radius}, borderWidth: ${borderWidth}, {x: ${x.toFixed(1)}, y: ${y.toFixed(1)}}`).toEqual(false);
+          }
+        }
+      });
+*/
+    });
+/*
+
+    elemsNoRad.forEach(function(element) {
+      it(`should return false radius is 0 element '${element.options.id}'`, function() {
+        for (const borderWidth of [0, 10]) {
+          const halfBorder = borderWidth / 2;
+          element.options.borderWidth = borderWidth;
+          for (const x of [element.x - halfBorder, element.x + halfBorder]) {
+            expect(element.inRange(x, element.y)).toEqual(false);
+          }
+          for (const y of [element.y - halfBorder, element.y + halfBorder]) {
+            expect(element.inRange(element.x, y)).toEqual(false);
+          }
+        }
+      });
+    });
+*/    
   });
 });

--- a/test/specs/polygon.spec.js
+++ b/test/specs/polygon.spec.js
@@ -4,76 +4,107 @@ describe('Polygon annotation', function() {
   describe('inRange', function() {
     const annotation1 = {
       type: 'polygon',
-      xValue: 7,
-      yValue: 7,
+      xValue: 1,
+      yValue: 1,
+      sides: 3,
       radius: 30
     };
     const annotation2 = {
       type: 'polygon',
-      xValue: 3,
-      yValue: 3,
-      radius: 0
+      xValue: 2,
+      yValue: 2,
+      sides: 4,
+      radius: 5
     };
     const annotation3 = {
       type: 'polygon',
+      xValue: 3,
+      yValue: 3,
+      sides: 5,
+      radius: 27
+    };
+    const annotation4 = {
+      type: 'polygon',
+      xValue: 4,
+      yValue: 4,
+      sides: 3,
+      rotation: 21,
+      radius: 20
+    };
+    const annotation5 = {
+      type: 'polygon',
       xValue: 5,
       yValue: 5,
+      sides: 4,
+      rotation: 131,
+      radius: 33
+    };
+    const annotation6 = {
+      type: 'polygon',
+      xValue: 6,
+      yValue: 6,
+      sides: 5,
+      rotation: 241,
+      radius: 24
+    };
+    const annotation7 = {
+      type: 'polygon',
+      xValue: 7,
+      yValue: 7,
+      sides: 5,
       radius: 0
     };
 
-    const chart = window.scatter10x10({annotation1, annotation2, annotation3});
+    const chart = window.scatter10x10({annotation1, annotation2, annotation3, annotation4, annotation5, annotation6, annotation7});
     const elems = window.getAnnotationElements(chart).filter(el => el.options.radius > 0);
     const elemsNoRad = window.getAnnotationElements(chart).filter(el => el.options.radius === 0);
 
     elems.forEach(function(element) {
+      const rotation = element.options.rotation;
+      const sides = element.options.sides;
+      const radius = element.height / 2;
+      const angle = (2 * Math.PI) / sides;
+
       it(`should return true inside element '${element.options.id}'`, function() {
-        const rotation = element.options.rotation;
-        for (let sides = 4; sides <= 4; sides++) {
-          element.options.sides = sides;
-          for (const borderWidth of [0]) {
-            const halfBorder = borderWidth / 2;
-            element.options.borderWidth = borderWidth;
-            const radius = element.height / 2;
-            const angle = (2 * Math.PI) / sides;
-            const vertices = [];
-            let rad = rotation * (Math.PI / 180);
-            for (let i = 0; i < sides; i++, rad += angle) {
-              const sin = Math.sin(rad);
-              const cos = Math.cos(rad);
-              vertices.push({
-                x: element.x + sin * (radius + halfBorder - 1),
-                y: element.y - cos * (radius + halfBorder - 1)
-              });
-            }
-            for (const vertex of vertices) {
-              //console.log('sides: '+ sides + ' borderWidth: ' + borderWidth + ' in: ' + element.inRange(vertex.x, vertex.y));
-              console.log({x: vertex.x, y: vertex.y}, {x: element.x, y: element.y, radius}, element.inRange(vertex.x, vertex.y));
-              //expect(element.inRange(vertex.x, vertex.y)).withContext(`sides: ${sides}, rotation: ${rotation}, radius: ${radius}, borderWidth: ${borderWidth}, {x: ${vertex.x.toFixed(1)}, y: ${vertex.y.toFixed(1)}}`).toEqual(true);
-            }
-          }
-        }
-      });
-/*
-
-
-      it(`should return false outside element '${element.options.id}'`, function() {
-        for (const borderWidth of [0, 10]) {
+        for (const borderWidth of [0]) {
           const halfBorder = borderWidth / 2;
           element.options.borderWidth = borderWidth;
-          const radius = element.height / 2;
-          for (const angle of [0, 45, 90, 135, 180, 225, 270, 315]) {
-            const rad = angle * (Math.PI / 180);
-            const {x, y} = {
-              x: element.x + Math.cos(rad) * (radius + halfBorder + 1),
-              y: element.y + Math.sin(rad) * (radius + halfBorder + 1)
-            };
-            expect(element.inRange(x, y)).withContext(`angle: ${angle}, radius: ${radius}, borderWidth: ${borderWidth}, {x: ${x.toFixed(1)}, y: ${y.toFixed(1)}}`).toEqual(false);
+          const vertices = [];
+          let rad = rotation * (Math.PI / 180);
+          for (let i = 0; i < sides; i++, rad += angle) {
+            const sin = Math.sin(rad);
+            const cos = Math.cos(rad);
+            vertices.push({
+              x: element.x + sin * (radius + halfBorder - 1),
+              y: element.y - cos * (radius + halfBorder - 1)
+            });
+          }
+          for (let vertex of vertices) {
+            expect(element.inRange(vertex.x, vertex.y)).withContext(`sides: ${sides}, rotation: ${rotation}, radius: ${radius}, borderWidth: ${borderWidth}, {x: ${vertex.x.toFixed(1)}, y: ${vertex.y.toFixed(1)}}`).toEqual(true);
           }
         }
       });
-*/
+
+      it(`should return false outside element '${element.options.id}'`, function() {
+        for (const borderWidth of [0]) {
+          const halfBorder = borderWidth / 2;
+          element.options.borderWidth = borderWidth;
+          const vertices = [];
+          let rad = rotation * (Math.PI / 180);
+          for (let i = 0; i < sides; i++, rad += angle) {
+            const sin = Math.sin(rad);
+            const cos = Math.cos(rad);
+            vertices.push({
+              x: element.x + sin * (radius + halfBorder + 1),
+              y: element.y - cos * (radius + halfBorder + 1)
+            });
+          }
+          for (let vertex of vertices) {
+            expect(element.inRange(vertex.x, vertex.y)).withContext(`sides: ${sides}, rotation: ${rotation}, radius: ${radius}, borderWidth: ${borderWidth}, {x: ${vertex.x.toFixed(1)}, y: ${vertex.y.toFixed(1)}}`).toEqual(false);
+          }
+        }
+      });
     });
-/*
 
     elemsNoRad.forEach(function(element) {
       it(`should return false radius is 0 element '${element.options.id}'`, function() {
@@ -89,6 +120,5 @@ describe('Polygon annotation', function() {
         }
       });
     });
-*/    
   });
 });

--- a/test/specs/polygon.spec.js
+++ b/test/specs/polygon.spec.js
@@ -14,7 +14,7 @@ describe('Polygon annotation', function() {
       type: 'polygon',
       xValue: 2,
       yValue: 2,
-      borderWidth: 0,
+      borderWidth: 10,
       sides: 4,
       radius: 5
     };
@@ -31,6 +31,7 @@ describe('Polygon annotation', function() {
       xValue: 4,
       yValue: 4,
       sides: 3,
+      borderWidth: 10,
       rotation: 21,
       radius: 20
     };
@@ -39,6 +40,7 @@ describe('Polygon annotation', function() {
       xValue: 5,
       yValue: 5,
       sides: 4,
+      borderWidth: 0,
       rotation: 131,
       radius: 33
     };
@@ -47,6 +49,7 @@ describe('Polygon annotation', function() {
       xValue: 6,
       yValue: 6,
       sides: 5,
+      borderWidth: 10,
       rotation: 241,
       radius: 24
     };
@@ -57,69 +60,71 @@ describe('Polygon annotation', function() {
       sides: 5,
       radius: 0
     };
+    const annotation8 = {
+      type: 'polygon',
+      xValue: 8,
+      yValue: 8,
+      borderWidth: 10,
+      sides: 5,
+      radius: 0
+    };
 
-    const chart = window.scatter10x10({annotation1, annotation2, annotation3, annotation4, annotation5, annotation6, annotation7});
+    const chart = window.scatter10x10({annotation1, annotation2, annotation3, annotation4, annotation5, annotation6, annotation7, annotation8});
     const elems = window.getAnnotationElements(chart).filter(el => el.options.radius > 0);
     const elemsNoRad = window.getAnnotationElements(chart).filter(el => el.options.radius === 0);
 
     elems.forEach(function(element) {
       const rotation = element.options.rotation;
       const sides = element.options.sides;
+      const borderWidth = element.options.borderWidth;
       const radius = element.height / 2;
       const angle = (2 * Math.PI) / sides;
 
       it(`should return true inside element '${element.options.id}'`, function() {
-        for (const borderWidth of [0]) {
-          const halfBorder = borderWidth / 2;
-          element.options.borderWidth = borderWidth;
-          const vertices = [];
-          let rad = rotation * (Math.PI / 180);
-          for (let i = 0; i < sides; i++, rad += angle) {
-            const sin = Math.sin(rad);
-            const cos = Math.cos(rad);
-            vertices.push({
-              x: element.x + sin * (radius + halfBorder - 1),
-              y: element.y - cos * (radius + halfBorder - 1)
-            });
-          }
-          for (let vertex of vertices) {
-            expect(element.inRange(vertex.x, vertex.y)).withContext(`sides: ${sides}, rotation: ${rotation}, radius: ${radius}, borderWidth: ${borderWidth}, {x: ${vertex.x.toFixed(1)}, y: ${vertex.y.toFixed(1)}}`).toEqual(true);
-          }
+        const halfBorder = borderWidth / 2;
+        const vertices = [];
+        let rad = rotation * (Math.PI / 180);
+        for (let i = 0; i < sides; i++, rad += angle) {
+          const sin = Math.sin(rad);
+          const cos = Math.cos(rad);
+          vertices.push({
+            x: element.x + sin * (radius + halfBorder - 1),
+            y: element.y - cos * (radius + halfBorder - 1)
+          });
+        }
+        for (let vertex of vertices) {
+          expect(element.inRange(vertex.x, vertex.y)).withContext(`sides: ${sides}, rotation: ${rotation}, radius: ${radius}, borderWidth: ${borderWidth}, {x: ${vertex.x.toFixed(1)}, y: ${vertex.y.toFixed(1)}}`).toEqual(true);
         }
       });
 
       it(`should return false outside element '${element.options.id}'`, function() {
-        for (const borderWidth of [0]) {
-          const halfBorder = borderWidth / 2;
-          element.options.borderWidth = borderWidth;
-          const vertices = [];
-          let rad = rotation * (Math.PI / 180);
-          for (let i = 0; i < sides; i++, rad += angle) {
-            const sin = Math.sin(rad);
-            const cos = Math.cos(rad);
-            vertices.push({
-              x: element.x + sin * (radius + halfBorder + 1),
-              y: element.y - cos * (radius + halfBorder + 1)
-            });
-          }
-          for (let vertex of vertices) {
-            expect(element.inRange(vertex.x, vertex.y)).withContext(`sides: ${sides}, rotation: ${rotation}, radius: ${radius}, borderWidth: ${borderWidth}, {x: ${vertex.x.toFixed(1)}, y: ${vertex.y.toFixed(1)}}`).toEqual(false);
-          }
+        const halfBorder = borderWidth / 2;
+        const vertices = [];
+        let rad = rotation * (Math.PI / 180);
+        for (let i = 0; i < sides; i++, rad += angle) {
+          const sin = Math.sin(rad);
+          const cos = Math.cos(rad);
+          vertices.push({
+            x: element.x + sin * (radius + halfBorder + 1),
+            y: element.y - cos * (radius + halfBorder + 1)
+          });
+        }
+        for (let vertex of vertices) {
+          expect(element.inRange(vertex.x, vertex.y)).withContext(`sides: ${sides}, rotation: ${rotation}, radius: ${radius}, borderWidth: ${borderWidth}, {x: ${vertex.x.toFixed(1)}, y: ${vertex.y.toFixed(1)}}`).toEqual(false);
         }
       });
     });
 
     elemsNoRad.forEach(function(element) {
       it(`should return false radius is 0 element '${element.options.id}'`, function() {
-        for (const borderWidth of [0, 10]) {
-          const halfBorder = borderWidth / 2;
-          element.options.borderWidth = borderWidth;
-          for (const x of [element.x - halfBorder, element.x + halfBorder]) {
-            expect(element.inRange(x, element.y)).toEqual(false);
-          }
-          for (const y of [element.y - halfBorder, element.y + halfBorder]) {
-            expect(element.inRange(element.x, y)).toEqual(false);
-          }
+        const borderWidth = element.options.borderWidth;
+        const halfBorder = borderWidth / 2;
+        element.options.borderWidth = borderWidth;
+        for (const x of [element.x - halfBorder, element.x + halfBorder]) {
+          expect(element.inRange(x, element.y)).toEqual(false);
+        }
+        for (const y of [element.y - halfBorder, element.y + halfBorder]) {
+          expect(element.inRange(element.x, y)).toEqual(false);
         }
       });
     });

--- a/test/specs/polygon.spec.js
+++ b/test/specs/polygon.spec.js
@@ -74,6 +74,7 @@ describe('Polygon annotation', function() {
     const elemsNoRad = window.getAnnotationElements(chart).filter(el => el.options.radius === 0);
 
     elems.forEach(function(element) {
+      const center = element.getCenterPoint();
       const rotation = element.options.rotation;
       const sides = element.options.sides;
       const borderWidth = element.options.borderWidth;
@@ -88,8 +89,8 @@ describe('Polygon annotation', function() {
           const sin = Math.sin(rad);
           const cos = Math.cos(rad);
           vertices.push({
-            x: element.x + sin * (radius + halfBorder - 1),
-            y: element.y - cos * (radius + halfBorder - 1)
+            x: center.x + sin * (radius + halfBorder - 1),
+            y: center.y - cos * (radius + halfBorder - 1)
           });
         }
         for (let vertex of vertices) {
@@ -105,8 +106,8 @@ describe('Polygon annotation', function() {
           const sin = Math.sin(rad);
           const cos = Math.cos(rad);
           vertices.push({
-            x: element.x + sin * (radius + halfBorder + 1),
-            y: element.y - cos * (radius + halfBorder + 1)
+            x: center.x + sin * (radius + halfBorder + 1),
+            y: center.y - cos * (radius + halfBorder + 1)
           });
         }
         for (let vertex of vertices) {
@@ -117,15 +118,7 @@ describe('Polygon annotation', function() {
 
     elemsNoRad.forEach(function(element) {
       it(`should return false radius is 0 element '${element.options.id}'`, function() {
-        const borderWidth = element.options.borderWidth;
-        const halfBorder = borderWidth / 2;
-        element.options.borderWidth = borderWidth;
-        for (const x of [element.x - halfBorder, element.x + halfBorder]) {
-          expect(element.inRange(x, element.y)).toEqual(false);
-        }
-        for (const y of [element.y - halfBorder, element.y + halfBorder]) {
-          expect(element.inRange(element.x, y)).toEqual(false);
-        }
+        expect(element.inRange(element.x, element.y)).toEqual(false);
       });
     });
   });

--- a/test/specs/polygon.spec.js
+++ b/test/specs/polygon.spec.js
@@ -6,6 +6,7 @@ describe('Polygon annotation', function() {
       type: 'polygon',
       xValue: 1,
       yValue: 1,
+      borderWidth: 0,
       sides: 3,
       radius: 30
     };
@@ -13,6 +14,7 @@ describe('Polygon annotation', function() {
       type: 'polygon',
       xValue: 2,
       yValue: 2,
+      borderWidth: 0,
       sides: 4,
       radius: 5
     };
@@ -20,6 +22,7 @@ describe('Polygon annotation', function() {
       type: 'polygon',
       xValue: 3,
       yValue: 3,
+      borderWidth: 0,
       sides: 5,
       radius: 27
     };

--- a/test/specs/polygon.spec.js
+++ b/test/specs/polygon.spec.js
@@ -83,35 +83,25 @@ describe('Polygon annotation', function() {
 
       it(`should return true inside element '${element.options.id}'`, function() {
         const halfBorder = borderWidth / 2;
-        const vertices = [];
         let rad = rotation * (Math.PI / 180);
         for (let i = 0; i < sides; i++, rad += angle) {
           const sin = Math.sin(rad);
           const cos = Math.cos(rad);
-          vertices.push({
-            x: center.x + sin * (radius + halfBorder - 1),
-            y: center.y - cos * (radius + halfBorder - 1)
-          });
-        }
-        for (let vertex of vertices) {
-          expect(element.inRange(vertex.x, vertex.y)).withContext(`sides: ${sides}, rotation: ${rotation}, radius: ${radius}, borderWidth: ${borderWidth}, {x: ${vertex.x.toFixed(1)}, y: ${vertex.y.toFixed(1)}}`).toEqual(true);
+          const x = center.x + sin * (radius + halfBorder - 1);
+          const y = center.y - cos * (radius + halfBorder - 1);
+          expect(element.inRange(x, y)).withContext(`sides: ${sides}, rotation: ${rotation}, radius: ${radius}, borderWidth: ${borderWidth}, {x: ${x.toFixed(1)}, y: ${y.toFixed(1)}}`).toEqual(true);
         }
       });
 
       it(`should return false outside element '${element.options.id}'`, function() {
         const halfBorder = borderWidth / 2;
-        const vertices = [];
         let rad = rotation * (Math.PI / 180);
         for (let i = 0; i < sides; i++, rad += angle) {
           const sin = Math.sin(rad);
           const cos = Math.cos(rad);
-          vertices.push({
-            x: center.x + sin * (radius + halfBorder + 1),
-            y: center.y - cos * (radius + halfBorder + 1)
-          });
-        }
-        for (let vertex of vertices) {
-          expect(element.inRange(vertex.x, vertex.y)).withContext(`sides: ${sides}, rotation: ${rotation}, radius: ${radius}, borderWidth: ${borderWidth}, {x: ${vertex.x.toFixed(1)}, y: ${vertex.y.toFixed(1)}}`).toEqual(false);
+          const x = center.x + sin * (radius + halfBorder + 1);
+          const y = center.y - cos * (radius + halfBorder + 1);
+          expect(element.inRange(x, y)).withContext(`sides: ${sides}, rotation: ${rotation}, radius: ${radius}, borderWidth: ${borderWidth}, {x: ${x.toFixed(1)}, y: ${y.toFixed(1)}}`).toEqual(false);
         }
       });
     });


### PR DESCRIPTION
This PR remove events test cases with inRange method tests.

it also adds a further check in `inRange` of polygon because if the radius is set to zero, the point (element.x, element.y) is accepted.

The approach for polygon is a little bit different comparing with point because the polygon is calculating the point elements (used in `inRange`) at initialization of the element.