### PR TITLE
Update the warning logic for missing scale

### DIFF
--- a/src/scale.js
+++ b/src/scale.js
@@ -29,10 +29,23 @@ function scaleLimitDefined(scaleOptions, limit, suggestedLimit) {
 
 function verifyScaleIDs(annotation, scales) {
   for (const key of ['scaleID', 'xScaleID', 'yScaleID']) {
-    if (annotation[key] && !scales[annotation[key]]) {
+    if (annotation[key] && !scales[annotation[key]] && verifyProperties(annotation, key)) {
       console.warn(`No scale found with id '${annotation[key]}' for annotation '${annotation.id}'`);
     }
   }
+}
+
+function verifyProperties(annotation, key) {
+  if (key === 'scaleID') {
+    return true;
+  }
+  const axis = key.charAt(0);
+  for (const prop of ['Min', 'Max', 'Value']) {
+    if (defined(annotation[axis + prop])) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function getScaleLimits(scale, annotations) {

--- a/test/specs/annotation.spec.js
+++ b/test/specs/annotation.spec.js
@@ -38,4 +38,108 @@ describe('Annotation plugin', function() {
 
     console.warn = origWarn;
   });
+
+  it('should emit console warning when unknown scale id is used', function() {
+    const origWarn = console.warn;
+    console.warn = jasmine.createSpy('warn');
+
+    acquireChart({
+      type: 'line',
+      options: {
+        plugins: {
+          annotation: {
+            annotations: [{
+              id: 'test',
+              type: 'box',
+              xScaleID: 'invalid',
+              xMin: 8
+            }]
+          }
+        }
+      }
+    });
+
+    expect(console.warn).toHaveBeenCalledWith('No scale found with id \'invalid\' for annotation \'test\'');
+
+    acquireChart({
+      type: 'line',
+      options: {
+        plugins: {
+          annotation: {
+            annotations: [{
+              id: 'test',
+              type: 'line',
+              scaleID: 'invalid',
+            }]
+          }
+        }
+      }
+    });
+
+    expect(console.warn).toHaveBeenCalledWith('No scale found with id \'invalid\' for annotation \'test\'');
+
+    console.warn = origWarn;
+  });
+
+  it('should not emit console warning when scale id is unknown or missing', function() {
+    const origWarn = console.warn;
+    console.warn = jasmine.createSpy('warn');
+
+    acquireChart({
+      type: 'line',
+      options: {
+        plugins: {
+          annotation: {
+            annotations: [{
+              id: 'test',
+              type: 'box',
+              xScaleID: 'invalid',
+              yScaleID: 'invalid'
+            }]
+          }
+        }
+      }
+    });
+
+    expect(console.warn.calls.count()).toBe(0);
+
+    acquireChart({
+      type: 'line',
+      data: {
+        datasets: [{
+          data: [40, 35, 79, 3, 55, 88, 36],
+          yScaleID: 'y1'
+        }]
+      },
+      options: {
+        scales: {
+          x: {
+            type: 'linear',
+            min: 0,
+            max: 6
+          },
+          y1: {
+            type: 'linear',
+            min: 0,
+            max: 100
+          }
+        },
+        plugins: {
+          annotation: {
+            annotations: [{
+              id: 'test',
+              type: 'line',
+              xMin: 1,
+              xMax: 1
+            }]
+          }
+        }
+      }
+    });
+
+    expect(console.warn.calls.count()).toBe(0);
+
+    console.warn = origWarn;
+  });
+
 });


### PR DESCRIPTION
Fix #662

The warning message will be emitted on the console if the scaleID is missing and also if there is any options to locate the annotation (`x/yValue`, `x/yMin` and  `x/yMax`).