### PR TITLE
Add dependencies label of PR to development section in release note

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -20,6 +20,7 @@ categories:
     labels:
       - 'chore'
       - 'performance'
+      - 'dependencies'
 exclude-labels:
   - 'infrastructure'
 change-template: '- #$NUMBER $TITLE'


### PR DESCRIPTION
Automatic PR to update dependencies are currently not managed in `release-draft`.

This PR adds `'dependencies'` label to `'Development'` section.