### PR TITLE
Move box annotation label to new sub-element of box annotation

### DIFF
--- a/src/elements.js
+++ b/src/elements.js
@@ -102,7 +102,8 @@ function getOrCreateElement({elements, index}, type, typesMap, initProperties) {
 }
 
 function resolveAnnotationOptions(resolver, typesMap) {
-  const elementClass = typesMap[resolveType(resolver.type, typesMap)];
+  const type = resolveType(resolver.type, typesMap);
+  const elementClass = typesMap[type];
   const result = {};
   result.id = resolver.id;
   result.type = resolver.type;
@@ -110,8 +111,10 @@ function resolveAnnotationOptions(resolver, typesMap) {
   Object.assign(result,
     resolveObj(resolver, elementClass.defaults),
     resolveObj(resolver, elementClass.defaultRoutes || {}));
-  for (const hook of hooks) {
-    result[hook] = resolver[hook];
+  if (annotationTypes[type]) {
+    for (const hook of hooks) {
+      result[hook] = resolver[hook];
+    }
   }
   return result;
 }

--- a/src/elements.js
+++ b/src/elements.js
@@ -80,9 +80,9 @@ function updateSubElements(mainElement, {elements, initProperties}, resolver, an
     const definition = elements[i];
     const properties = definition.properties;
     const subElement = getOrCreateElement(subElements, i, definition.type, initProperties);
-    subElement.parent = mainElement;
     const subResolver = resolver[definition.optionScope].override(definition);
     properties.options = resolveAnnotationOptions(subResolver);
+    properties.mainElement = mainElement;
     animations.update(subElement, properties);
   }
 }
@@ -107,7 +107,7 @@ function resolveAnnotationOptions(resolver) {
   result.drawTime = resolver.drawTime;
   Object.assign(result,
     resolveObj(resolver, elementClass.defaults),
-    resolveObj(resolver, elementClass.defaultRoutes));
+    resolveObj(resolver, elementClass.defaultRoutes || {}));
   for (const hook of hooks) {
     result[hook] = resolver[hook];
   }

--- a/src/elements.js
+++ b/src/elements.js
@@ -80,6 +80,7 @@ function updateSubElements(mainElement, {elements, initProperties}, resolver, an
     const definition = elements[i];
     const properties = definition.properties;
     const subElement = getOrCreateElement(subElements, i, definition.type, initProperties);
+    subElement.parent = mainElement;
     const subResolver = resolver[definition.optionScope].override(definition);
     properties.options = resolveAnnotationOptions(subResolver);
     animations.update(subElement, properties);

--- a/src/types/box.js
+++ b/src/types/box.js
@@ -1,6 +1,6 @@
 import {Element} from 'chart.js';
-import {toPadding, toRadians} from 'chart.js/helpers';
-import {drawBox, drawLabel, getRelativePosition, measureLabelSize, getRectCenterPoint, getChartRect, toPosition, inBoxRange, rotated, translate} from '../helpers';
+import {toRadians} from 'chart.js/helpers';
+import {drawBox, getRectCenterPoint, getChartRect, inBoxRange, rotated, translate} from '../helpers';
 import BoxAnnotationLabel from './boxLabel';
 
 export default class BoxAnnotation extends Element {
@@ -21,40 +21,16 @@ export default class BoxAnnotation extends Element {
     ctx.restore();
   }
 
-  drawLabel(ctx) {
-/*
-    const {x, y, width, height, options} = this;
-    const {label, borderWidth} = options;
-    const halfBorder = borderWidth / 2;
-    const position = toPosition(label.position);
-    const padding = toPadding(label.padding);
-    const labelSize = measureLabelSize(ctx, label);
-    const labelRect = {
-      x: calculateX(this, labelSize, position, padding),
-      y: calculateY(this, labelSize, position, padding),
-      width: labelSize.width,
-      height: labelSize.height
-    };
-
-    ctx.save();
-    translate(ctx, this, label.rotation);
-    ctx.beginPath();
-    ctx.rect(x + halfBorder + padding.left, y + halfBorder + padding.top,
-      width - borderWidth - padding.width, height - borderWidth - padding.height);
-    ctx.clip();
-    drawLabel(ctx, labelRect, label);
-    ctx.restore();
-*/
-  }
-
   resolveElementProperties(chart, options) {
     const properties = getChartRect(chart, options);
+    const {x, y} = properties;
     const label = new BoxAnnotationLabel();
     properties.elements = [{
-        type: 'boxLabel',
-        optionScope: 'label',
-        properties: label.resolveElementProperties(chart, properties, options)
-      }];
+      type: 'boxLabel',
+      optionScope: 'label',
+      properties: label.resolveElementProperties(chart, properties, options)
+    }];
+    properties.initProperties = {x, y};
     return properties;
   }
 }
@@ -73,30 +49,7 @@ BoxAnnotation.defaults = {
   borderWidth: 1,
   cornerRadius: undefined, // TODO: v2 remove support for cornerRadius
   display: true,
-  label: {
-    borderWidth: undefined,
-    color: 'black',
-    content: null,
-    drawTime: undefined,
-    enabled: false,
-    font: {
-      family: undefined,
-      lineHeight: undefined,
-      size: undefined,
-      style: undefined,
-      weight: 'bold'
-    },
-    height: undefined,
-    padding: 6,
-    position: 'center',
-    rotation: undefined,
-    textAlign: 'start',
-    textStrokeColor: undefined,
-    textStrokeWidth: 0,
-    xAdjust: 0,
-    yAdjust: 0,
-    width: undefined
-  },
+  label: BoxAnnotationLabel.defaults,
   rotation: 0,
   shadowBlur: 0,
   shadowOffsetX: 0,

--- a/src/types/box.js
+++ b/src/types/box.js
@@ -1,6 +1,7 @@
 import {Element} from 'chart.js';
 import {toPadding, toRadians} from 'chart.js/helpers';
 import {drawBox, drawLabel, getRelativePosition, measureLabelSize, getRectCenterPoint, getChartRect, toPosition, inBoxRange, rotated, translate} from '../helpers';
+import BoxAnnotationLabel from './boxLabel';
 
 export default class BoxAnnotation extends Element {
   inRange(mouseX, mouseY, useFinalPosition) {
@@ -21,6 +22,7 @@ export default class BoxAnnotation extends Element {
   }
 
   drawLabel(ctx) {
+/*
     const {x, y, width, height, options} = this;
     const {label, borderWidth} = options;
     const halfBorder = borderWidth / 2;
@@ -42,10 +44,18 @@ export default class BoxAnnotation extends Element {
     ctx.clip();
     drawLabel(ctx, labelRect, label);
     ctx.restore();
+*/
   }
 
   resolveElementProperties(chart, options) {
-    return getChartRect(chart, options);
+    const properties = getChartRect(chart, options);
+    const label = new BoxAnnotationLabel();
+    properties.elements = [{
+        type: 'boxLabel',
+        optionScope: 'label',
+        properties: label.resolveElementProperties(chart, properties, options)
+      }];
+    return properties;
   }
 }
 
@@ -109,32 +119,3 @@ BoxAnnotation.descriptors = {
     _fallback: true
   }
 };
-
-function calculateX(box, labelSize, position, padding) {
-  const {x: start, x2: end, width: size, options} = box;
-  const {xAdjust: adjust, borderWidth} = options.label;
-  return calculatePosition({start, end, size}, {
-    position: position.x,
-    padding: {start: padding.left, end: padding.right},
-    adjust, borderWidth,
-    size: labelSize.width
-  });
-}
-
-function calculateY(box, labelSize, position, padding) {
-  const {y: start, y2: end, height: size, options} = box;
-  const {yAdjust: adjust, borderWidth} = options.label;
-  return calculatePosition({start, end, size}, {
-    position: position.y,
-    padding: {start: padding.top, end: padding.bottom},
-    adjust, borderWidth,
-    size: labelSize.height
-  });
-}
-
-function calculatePosition(boxOpts, labelOpts) {
-  const {start, end} = boxOpts;
-  const {position, padding: {start: padStart, end: padEnd}, adjust, borderWidth} = labelOpts;
-  const availableSize = end - borderWidth - start - padStart - padEnd - labelOpts.size;
-  return start + borderWidth / 2 + adjust + padStart + getRelativePosition(availableSize, position);
-}

--- a/src/types/box.js
+++ b/src/types/box.js
@@ -1,7 +1,7 @@
 import {Element} from 'chart.js';
 import {toRadians} from 'chart.js/helpers';
 import {drawBox, getRectCenterPoint, getChartRect, inBoxRange, rotated, translate} from '../helpers';
-import BoxAnnotationLabel from './boxLabel';
+import BoxAnnotationLabel, {resolveElementProperties} from './boxLabel';
 
 export default class BoxAnnotation extends Element {
   inRange(mouseX, mouseY, useFinalPosition) {
@@ -24,11 +24,10 @@ export default class BoxAnnotation extends Element {
   resolveElementProperties(chart, options) {
     const properties = getChartRect(chart, options);
     const {x, y} = properties;
-    const label = new BoxAnnotationLabel();
     properties.elements = [{
       type: 'boxLabel',
       optionScope: 'label',
-      properties: label.resolveElementProperties(chart, properties, options)
+      properties: resolveElementProperties(chart, properties, options)
     }];
     properties.initProperties = {x, y};
     return properties;

--- a/src/types/boxLabel.js
+++ b/src/types/boxLabel.js
@@ -39,8 +39,6 @@ export default class BoxAnnotationLabel extends Element {
   }
 }
 
-BoxAnnotationLabel.id = 'boxAnnotationLabel';
-
 BoxAnnotationLabel.defaults = {
   borderWidth: undefined,
   color: 'black',

--- a/src/types/boxLabel.js
+++ b/src/types/boxLabel.js
@@ -24,19 +24,6 @@ export default class BoxAnnotationLabel extends Element {
     ctx.restore();
   }
 
-  resolveElementProperties(chart, properties, options) {
-    const label = options.label;
-    const position = toPosition(label.position);
-    const padding = toPadding(label.padding);
-    const labelSize = measureLabelSize(chart.ctx, label);
-    return {
-      x: calculateX({properties, options}, labelSize, position, padding),
-      y: calculateY({properties, options}, labelSize, position, padding),
-      width: labelSize.width,
-      height: labelSize.height,
-      options: label
-    };
-  }
 }
 
 BoxAnnotationLabel.defaults = {
@@ -63,6 +50,20 @@ BoxAnnotationLabel.defaults = {
   yAdjust: 0,
   width: undefined
 };
+
+export function resolveElementProperties(chart, properties, options) {
+  const label = options.label;
+  const position = toPosition(label.position);
+  const padding = toPadding(label.padding);
+  const labelSize = measureLabelSize(chart.ctx, label);
+  return {
+    x: calculateX({properties, options}, labelSize, position, padding),
+    y: calculateY({properties, options}, labelSize, position, padding),
+    width: labelSize.width,
+    height: labelSize.height,
+    options: label
+  };
+}
 
 function labelIsVisible(options) {
   return options && options.enabled && options.content;

--- a/src/types/boxLabel.js
+++ b/src/types/boxLabel.js
@@ -1,0 +1,97 @@
+import {Element} from 'chart.js';
+import {toPadding, toRadians} from 'chart.js/helpers';
+import {drawBox, drawLabel, getRelativePosition, measureLabelSize, getRectCenterPoint, getChartRect, toPosition, inBoxRange, rotated, translate} from '../helpers';
+
+export default class BoxAnnotationLabel extends Element {
+
+  draw(ctx) {
+    const {x, y, width, height, parent, options} = this;
+    const borderWidth = parent.options.borderWidth;
+    const halfBorder = borderWidth / 2;
+    const padding = toPadding(options.padding);
+    
+    ctx.save();
+    translate(ctx, parent, options.rotation);
+    ctx.beginPath();
+    ctx.rect(x + halfBorder + padding.left, y + halfBorder + padding.top,
+      width - borderWidth - padding.width, height - borderWidth - padding.height);
+    ctx.clip();
+    drawLabel(ctx, this, options);
+    ctx.restore();
+  }
+
+  resolveElementProperties(chart, properties, options) {
+    const {x, y, width, height} = properties;
+    const {label, borderWidth} = options;
+    const halfBorder = borderWidth / 2;
+    const position = toPosition(label.position);
+    const padding = toPadding(label.padding);
+    const labelSize = measureLabelSize(chart.ctx, label);
+    return {
+      x: calculateX({properties, options}, labelSize, position, padding),
+      y: calculateY({properties, options}, labelSize, position, padding),
+      width: labelSize.width,
+      height: labelSize.height,
+      options: label
+    };
+  }
+}
+
+BoxAnnotationLabel.id = 'boxAnnotationLabel';
+
+BoxAnnotationLabel.defaults = {
+  borderWidth: undefined,
+  color: 'black',
+  content: null,
+  drawTime: undefined,
+  enabled: false,
+  font: {
+    family: undefined,
+    lineHeight: undefined,
+    size: undefined,
+    style: undefined,
+    weight: 'bold'
+  },
+  height: undefined,
+  padding: 6,
+  position: 'center',
+  rotation: undefined,
+  textAlign: 'start',
+  textStrokeColor: undefined,
+  textStrokeWidth: 0,
+  xAdjust: 0,
+  yAdjust: 0,
+  width: undefined
+};
+
+BoxAnnotationLabel.defaultRoutes = {
+};
+
+function calculateX({properties, options}, labelSize, position, padding) {
+  const {x: start, x2: end, width: size} = properties;
+  const {xAdjust: adjust, borderWidth} = options.label;
+  return calculatePosition({start, end, size}, {
+    position: position.x,
+    padding: {start: padding.left, end: padding.right},
+    adjust, borderWidth,
+    size: labelSize.width
+  });
+}
+
+function calculateY({properties, options}, labelSize, position, padding) {
+  const {y: start, y2: end, height: size} = properties;
+  const {yAdjust: adjust, borderWidth} = options.label;
+  return calculatePosition({start, end, size}, {
+    position: position.y,
+    padding: {start: padding.top, end: padding.bottom},
+    adjust, borderWidth,
+    size: labelSize.height
+  });
+}
+
+function calculatePosition(boxOpts, labelOpts) {
+  const {start, end} = boxOpts;
+  const {position, padding: {start: padStart, end: padEnd}, adjust, borderWidth} = labelOpts;
+  const availableSize = end - borderWidth - start - padStart - padEnd - labelOpts.size;
+  return start + borderWidth / 2 + adjust + padStart + getRelativePosition(availableSize, position);
+}

--- a/src/types/boxLabel.js
+++ b/src/types/boxLabel.js
@@ -1,29 +1,31 @@
 import {Element} from 'chart.js';
-import {toPadding, toRadians} from 'chart.js/helpers';
-import {drawBox, drawLabel, getRelativePosition, measureLabelSize, getRectCenterPoint, getChartRect, toPosition, inBoxRange, rotated, translate} from '../helpers';
+import {toPadding} from 'chart.js/helpers';
+import {drawLabel, getRelativePosition, measureLabelSize, toPosition, translate} from '../helpers';
 
 export default class BoxAnnotationLabel extends Element {
 
   draw(ctx) {
-    const {x, y, width, height, parent, options} = this;
-    const borderWidth = parent.options.borderWidth;
+    const {x, y, width, height, options} = this.mainElement;
+    const label = options.label;
+    if (!labelIsVisible(label)) {
+      return;
+    }
+    const borderWidth = options.borderWidth;
     const halfBorder = borderWidth / 2;
-    const padding = toPadding(options.padding);
-    
+    const padding = toPadding(label.padding);
+
     ctx.save();
-    translate(ctx, parent, options.rotation);
+    translate(ctx, this.mainElement, label.rotation);
     ctx.beginPath();
     ctx.rect(x + halfBorder + padding.left, y + halfBorder + padding.top,
       width - borderWidth - padding.width, height - borderWidth - padding.height);
     ctx.clip();
-    drawLabel(ctx, this, options);
+    drawLabel(ctx, this, label);
     ctx.restore();
   }
 
   resolveElementProperties(chart, properties, options) {
-    const {x, y, width, height} = properties;
-    const {label, borderWidth} = options;
-    const halfBorder = borderWidth / 2;
+    const label = options.label;
     const position = toPosition(label.position);
     const padding = toPadding(label.padding);
     const labelSize = measureLabelSize(chart.ctx, label);
@@ -64,8 +66,9 @@ BoxAnnotationLabel.defaults = {
   width: undefined
 };
 
-BoxAnnotationLabel.defaultRoutes = {
-};
+function labelIsVisible(options) {
+  return options && options.enabled && options.content;
+}
 
 function calculateX({properties, options}, labelSize, position, padding) {
   const {x: start, x2: end, width: size} = properties;

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -9,7 +9,6 @@ import PolygonAnnotation from './polygon';
 
 export const annotationTypes = {
   box: BoxAnnotation,
-  boxLabel: BoxAnnotationLabel,
   ellipse: EllipseAnnotation,
   label: LabelAnnotation,
   line: LineAnnotation,
@@ -17,9 +16,12 @@ export const annotationTypes = {
   polygon: PolygonAnnotation
 };
 
+export const subElementTypes = {
+  boxLabel: BoxAnnotationLabel
+};
+
 export {
   BoxAnnotation,
-  BoxAnnotationLabel,
   LineAnnotation,
   EllipseAnnotation,
   LabelAnnotation,

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -19,6 +19,7 @@ export const annotationTypes = {
 
 export {
   BoxAnnotation,
+  BoxAnnotationLabel,
   LineAnnotation,
   EllipseAnnotation,
   LabelAnnotation,

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -1,5 +1,6 @@
 import {defaults} from 'chart.js';
 import BoxAnnotation from './box';
+import BoxAnnotationLabel from './boxLabel';
 import LineAnnotation from './line';
 import EllipseAnnotation from './ellipse';
 import LabelAnnotation from './label';
@@ -8,6 +9,7 @@ import PolygonAnnotation from './polygon';
 
 export const annotationTypes = {
   box: BoxAnnotation,
+  boxLabel: BoxAnnotationLabel,
   ellipse: EllipseAnnotation,
   label: LabelAnnotation,
   line: LineAnnotation,


### PR DESCRIPTION
This PR moves `label` node of box annotation to sub element.

This PR enables the box label animation.