### PR TITLE
Fix point sample on combined annotations

### DIFF
--- a/docs/samples/point/combined.md
+++ b/docs/samples/point/combined.md
@@ -37,6 +37,7 @@ const annotation1 = {
     end: {
       enabled: true,
       fill: true,
+      borderDash: [],
       borderColor: 'green'
     }
   },


### PR DESCRIPTION
Fix point sample on combined annotations, resetting `borderDash` option.