### PR TITLE
Remove the assignment used only once

### DIFF
--- a/src/types/box.js
+++ b/src/types/box.js
@@ -13,9 +13,8 @@ export default class BoxAnnotation extends Element {
   }
 
   draw(ctx) {
-    const rotation = this.options.rotation;
     ctx.save();
-    translate(ctx, this, rotation);
+    translate(ctx, this, this.options.rotation);
     drawBox(ctx, this, this.options);
     ctx.restore();
   }


### PR DESCRIPTION
Remove the assignment of rotation in box annotation, used only once.