### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/helpers/helpers.core.js
+++ b/src/helpers/helpers.core.js
@@ -30,7 +30,7 @@ export function getElementCenterPoint(element, useFinalPosition) {
   return {x, y};
 }
 
-const isOlderPart = (act, req) => req > act || (act.length > req.length && act.substr(0, req.length) === req);
+const isOlderPart = (act, req) => req > act || (act.length > req.length && act.slice(0, req.length) === req);
 
 export function requireVersion(pkg, min, ver, strict = true) {
   const parts = ver.split('.');


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.
