### PR TITLE
Move v3-migration.md file in the documentation

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -98,6 +98,7 @@ module.exports = {
             'types/polygon'
           ]
         },
+        'migrationV1',
         'migrationV2'
       ],
       '/samples/': [

--- a/docs/guide/migrationV1.md
+++ b/docs/guide/migrationV1.md
@@ -1,10 +1,10 @@
-# 3.x Migration Guide
+# 1.x Migration Guide
 
-chartjs-plugin-annotation 3.0 introduces a number of breaking changes.
+`chartjs-plugin-annotation` plugin version 1 introduces a number of breaking changes in order to compatible with Chart.js 3 and to align with Chart.js 3 options.
 
 ## Setup and installation
 
-* Chart.js 3 is tree-shakeable and thus requires registering the plugins when used as an `npm` module. Here is an example:
+Chart.js 3 is tree-shakeable and thus requires registering the plugins when used as an `npm` module. Here is an example:
 
 ```javascript
 import { Chart, LineController, LineElement, PointElement, LinearScale } from 'chart.js';


### PR DESCRIPTION
Fix #714 

This PR is moving the migration guide of plugin to version1 in the documentation.