### PR TITLE
Require at least chartjs v3.7

### DIFF
--- a/docs/guide/migrationV2.md
+++ b/docs/guide/migrationV2.md
@@ -2,6 +2,10 @@
 
 `chartjs-plugin-annotation` plugin version 2 introduces a number of breaking changes. In order to improve performance, offer new features, and improve maintainability, it was necessary to break backwards compatibility, but we aimed to do so only when worth the benefit.
 
+## Chart.js version
+
+The annotation plugin requires at least version 3.7.0 to work because of some bug fixes that happend within chart.js itself.
+
 ## Options
 
 A number of changes were made to the configuration options passed to the plugin configuration. Those changes are documented below.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@simonbrunel/vuepress-plugin-versions": "^0.2.0",
         "@typescript-eslint/eslint-plugin": "^5.4.0",
         "@typescript-eslint/parser": "^5.4.0",
-        "chart.js": "^3.1.0",
+        "chart.js": "^3.7.0",
         "chartjs-plugin-autocolors": "^0.0.5",
         "chartjs-test-utils": "^0.4.0",
         "concurrently": "^7.0.0",
@@ -44,7 +44,7 @@
         "vuepress-theme-chartjs": "^0.2.0"
       },
       "peerDependencies": {
-        "chart.js": "^3.1.0"
+        "chart.js": "^3.7.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@simonbrunel/vuepress-plugin-versions": "^0.2.0",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
-    "chart.js": "^3.1.0",
+    "chart.js": "^3.7.0",
     "chartjs-plugin-autocolors": "^0.0.5",
     "chartjs-test-utils": "^0.4.0",
     "concurrently": "^7.0.0",
@@ -68,6 +68,6 @@
     "vuepress-theme-chartjs": "^0.2.0"
   },
   "peerDependencies": {
-    "chart.js": "^3.1.0"
+    "chart.js": "^3.7.0"
   }
 }

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -14,26 +14,12 @@ export default {
 
   version,
 
-  /* TODO: enable in v2
   beforeRegister() {
     requireVersion('chart.js', '3.7', Chart.version);
   },
-  */
 
   afterRegister() {
     Chart.register(annotationTypes);
-
-    // TODO: Remove this check, warning and workaround in v2
-    if (!requireVersion('chart.js', '3.7', Chart.version, false)) {
-      console.warn(`${name} has known issues with chart.js versions prior to 3.7, please consider upgrading.`);
-
-      // Workaround for https://github.com/chartjs/chartjs-plugin-annotation/issues/572
-      Chart.defaults.set('elements.lineAnnotation', {
-        callout: {},
-        font: {},
-        padding: 6
-      });
-    }
   },
 
   afterUnregister() {

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -5,7 +5,7 @@ import {adjustScaleRange, verifyScaleOptions} from './scale';
 import {updateElements, resolveType} from './elements';
 import {annotationTypes} from './types';
 import {requireVersion} from './helpers';
-import {name, version} from '../package.json';
+import {version} from '../package.json';
 
 const chartStates = new Map();
 


### PR DESCRIPTION
Remove todo for V2.

Although not sure if we want it to be minimal 3.7 because of the bugfix or 3.8 if we want to remove this todo as wel:
https://github.com/chartjs/chartjs-plugin-annotation/blob/70078ccbe49568f6a4106667ad008bef7edf5495/src/helpers/helpers.canvas.js#L07-L18