### PR TITLE
Move interaction object at top level of plugin options

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -11,6 +11,7 @@ The following options are available at the top level. They apply to all annotati
 | [`animations`](#animations) | `object` | No | [see here](#default-animations) | To configure which element properties are animated and how.
 | `clip` | `boolean` | No | `true` | Are the annotations clipped to the chartArea.
 | [`common`](#common) | `Object` | No | | To configure common options apply to all annotations
+| [`interaction`](options#interaction) | `Object` | No | `options.interaction` | To configure which events trigger plugin interactions
 
 :::warning
 
@@ -63,7 +64,6 @@ The following options apply to all annotations unless they are overwritten on a 
 | Name | Type | [Scriptable](options#scriptable-options) | Default | Notes
 | ---- | ---- | :----: | ---- | ----
 | `drawTime` | `string` | Yes | `'afterDatasetsDraw'` | See [drawTime](options#draw-time).
-| [`interaction`](options#interaction) | `Object` | No | `options.interaction` | To configure which events trigger plugin interactions
 
 ## Events
 

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -108,13 +108,13 @@ export default {
       },
     },
     clip: true,
+    interaction: {
+      mode: undefined,
+      axis: undefined,
+      intersect: undefined
+    },
     common: {
       drawTime: 'afterDatasetsDraw',
-      interaction: {
-        mode: undefined,
-        axis: undefined,
-        intersect: undefined
-      },
       label: {
       }
     }
@@ -127,10 +127,10 @@ export default {
       _allKeys: false,
       _fallback: (prop, opts) => `elements.${annotationTypes[resolveType(opts.type)].id}`
     },
+    interaction: {
+      _fallback: true
+    },
     common: {
-      interaction: {
-        _fallback: true
-      },
       label: {
         _fallback: true
       }

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -152,13 +152,13 @@ interface PolygonAnnotationOptions extends CoreAnnotationOptions, AnnotationPoin
 }
 
 export interface AnnotationPluginCommonOptions {
-  drawTime?: Scriptable<DrawTime, PartialEventContext>,
-  interaction?: CoreInteractionOptions
+  drawTime?: Scriptable<DrawTime, PartialEventContext>
 }
 
 export interface AnnotationPluginOptions extends AnnotationEvents {
   animations?: Record<string, unknown>,
   annotations: AnnotationOptions[] | Record<string, AnnotationOptions>,
   clip?: boolean,
-  common?: AnnotationPluginCommonOptions
+  common?: AnnotationPluginCommonOptions,
+  interaction?: CoreInteractionOptions
 }

--- a/types/tests/exports.ts
+++ b/types/tests/exports.ts
@@ -16,12 +16,13 @@ const chart = new Chart('id', {
     plugins: {
       annotation: {
         clip: false,
+        interaction: {
+          mode: 'nearest',
+          axis: 'xy',
+          intersect: true
+        },
         common: {
-          interaction: {
-            mode: 'nearest',
-            axis: 'xy',
-            intersect: true
-          }
+          drawTime: 'afterDraw'
         },
         annotations: [{
           type: 'line',


### PR DESCRIPTION
The `interaction` object has been moved at top level of plugin options, instead of common object as implemented by PR #630.

This is because the `interaction` is not configurable at annotation instance but is a plugin configuration, like `clip` one.