### PR TITLE
Reduce complexity for resolving the label callout position

### DIFF
--- a/src/types/label.js
+++ b/src/types/label.js
@@ -221,7 +221,7 @@ function getCalloutSideAdjust(position, options) {
 
 function resolveCalloutPosition(element, options) {
   const position = options.position;
-  if (positions.indexOf(position) >= 0) {
+  if (positions.includes(position)) {
     return position;
   }
   return resolveCalloutAutoPosition(element, options);

--- a/src/types/label.js
+++ b/src/types/label.js
@@ -221,7 +221,7 @@ function getCalloutSideAdjust(position, options) {
 
 function resolveCalloutPosition(element, options) {
   const position = options.position;
-  if (position === 'left' || position === 'right' || position === 'top' || position === 'bottom') {
+  if (positions.indexOf(position) >=0) {
     return position;
   }
   return resolveCalloutAutoPosition(element, options);

--- a/src/types/label.js
+++ b/src/types/label.js
@@ -221,7 +221,7 @@ function getCalloutSideAdjust(position, options) {
 
 function resolveCalloutPosition(element, options) {
   const position = options.position;
-  if (positions.indexOf(position) >=0) {
+  if (positions.indexOf(position) >= 0) {
     return position;
   }
   return resolveCalloutAutoPosition(element, options);


### PR DESCRIPTION
This reduces complexity using the enumerated callout position values to check if manageable instead of an if statement with for conditions in OR.