### PR TITLE
Remove destroy plugin hook and replaced with afterDestroy

### DIFF
--- a/src/annotation.js
+++ b/src/annotation.js
@@ -92,7 +92,7 @@ export default {
     }
   },
 
-  destroy(chart) {
+  afterDestroy(chart) {
     chartStates.delete(chart);
   },
 


### PR DESCRIPTION
With CHART.JS 4, PR https://github.com/chartjs/Chart.js/pull/10549, the `destroy` plugin hook has been removed and replaced with `afterDestroy`.
Currently, the version 2.1.0 is not cleaning the states map.