### PR TITLE
Fix links with anchors adding md extension in the documentation

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -6,12 +6,12 @@ title: Configuration
 
 The following options are available at the top level. They apply to all annotations unless they are overwritten on a per-annotation basis.
 
-| Name | Type | [Scriptable](options#scriptable-options) | Default | Notes
+| Name | Type | [Scriptable](options.md#scriptable-options) | Default | Notes
 | ---- | ---- | :----: | ---- | ----
 | [`animations`](#animations) | `object` | No | [see here](#default-animations) | To configure which element properties are animated and how.
 | `clip` | `boolean` | No | `true` | Are the annotations clipped to the chartArea.
 | [`common`](#common) | `Object` | No | | To configure common options apply to all annotations
-| [`interaction`](options#interaction) | `Object` | No | `options.interaction` | To configure which events trigger plugin interactions
+| [`interaction`](options.md#interaction) | `Object` | No | `options.interaction` | To configure which events trigger plugin interactions
 
 :::warning
 
@@ -61,9 +61,9 @@ const options = {
 
 The following options apply to all annotations unless they are overwritten on a per-annotation basis.
 
-| Name | Type | [Scriptable](options#scriptable-options) | Default | Notes
+| Name | Type | [Scriptable](options.md#scriptable-options) | Default | Notes
 | ---- | ---- | :----: | ---- | ----
-| `drawTime` | `string` | Yes | `'afterDatasetsDraw'` | See [drawTime](options#draw-time).
+| `drawTime` | `string` | Yes | `'afterDatasetsDraw'` | See [drawTime](options.md#draw-time).
 
 ## Events
 

--- a/docs/guide/migrationV2.md
+++ b/docs/guide/migrationV2.md
@@ -102,7 +102,7 @@ The following diagram is showing the element properties about a `'polygon'` anno
 
 ## Events
 
-`chartjs-plugin-annotation` plugin version 2 introduces the [`interaction`](options#interaction) options, to configure which events trigger annotation interactions. By default, the plugin uses the [chart interaction configuration](https://www.chartjs.org/docs/latest/configuration/interactions.html#interactions).
+`chartjs-plugin-annotation` plugin version 2 introduces the [`interaction`](options.md#interaction) options, to configure which events trigger annotation interactions. By default, the plugin uses the [chart interaction configuration](https://www.chartjs.org/docs/latest/configuration/interactions.html#interactions).
 
  * When [scatter charts](https://www.chartjs.org/docs/latest/charts/scatter.html) are used, the interaction default `mode` in Chart.js is `point`, while, in the previous plugin version, the default was `nearest`.
 

--- a/docs/guide/options.md
+++ b/docs/guide/options.md
@@ -37,7 +37,6 @@ The function receives 2 arguments, first is the [option context](#option-context
 /* <block:options:0> */
 const options = {
   plugins: {
-    autocolors: false,
     annotation: {
       annotations: {
         box1: {

--- a/docs/guide/types/_commonInnerLabel.md
+++ b/docs/guide/types/_commonInnerLabel.md
@@ -2,21 +2,21 @@
 
 Namespace: `options.annotations[annotationID].label`, it defines options for the the label of annotation.
 
-All of these options can be [Scriptable](../options#scriptable-options)
+All of these options can be [Scriptable](../options.md#scriptable-options)
 
 | Name | Type | Default | Notes
 | ---- | ---- | :----: | ----
-| `color` | [`Color`](../options#color) | `'black'` | Text color.
+| `color` | [`Color`](../options.md#color) | `'black'` | Text color.
 | `content` | `string`\|`string[]`\|[`Image`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image)\|[`HTMLCanvasElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement) | `null` | The content to show in the label.
 | `display` | `boolean` | `false` | Whether or not the label is shown.
-| `drawTime` | `string` | `options.drawTime` | See [drawTime](../options#draw-time). Defaults to the annotation draw time if unset
-| `font` | [`Font`](../options#font) | `{ weight: 'bold' }` | Label font
+| `drawTime` | `string` | `options.drawTime` | See [drawTime](../options.md#draw-time). Defaults to the annotation draw time if unset
+| `font` | [`Font`](../options.md#font) | `{ weight: 'bold' }` | Label font
 | `height` | `number`\|`string` | `undefined` | Overrides the height of the image or canvas element. Could be set in pixel by a number, or in percentage of current height of image or canvas element by a string. If undefined, uses the height of the image or canvas element. It is used only when the content is an image or canvas element.
-| `padding` | [`Padding`](../options#padding) | `6` | The padding to add around the text label.
+| `padding` | [`Padding`](../options.md#padding) | `6` | The padding to add around the text label.
 | [`position`](#position) | `string`\|`{x: string, y: string}` | `'center'` | Anchor position of label in the annotation.
 | `rotation` | `number` | `undefined` | Rotation of label, in degrees. If `undefined`, the annotation rotation is used.
 | `textAlign` | `string` | `'start'` | Text alignment of label content when there's more than one line. Possible options are: `'left'`, `'start'`, `'center'`, `'end'`, `'right'`.
-| `textStrokeColor` | [`Color`](../options#color) | `undefined` | The color of the stroke around the text.
+| `textStrokeColor` | [`Color`](../options.md#color) | `undefined` | The color of the stroke around the text.
 | `textStrokeWidth` | `number` | `0` | Stroke width around the text.
 | `width` | `number`\|`string` | `undefined` | Overrides the width of the image or canvas element. Could be set in pixel by a number, or in percentage of current width of image or canvas element by a string. If undefined, uses the width of the image or canvas element. It is used only when the content is an image or canvas element.
 | `xAdjust` | `number` | `0` | Adjustment along x-axis (left-right) of label relative to computed position. Negative values move the label left, positive right.

--- a/docs/guide/types/_commonOptions.md
+++ b/docs/guide/types/_commonOptions.md
@@ -2,14 +2,14 @@
 
 The following options are available for all annotations.
 
-| Name | Type | [Scriptable](../options#scriptable-options) | Default
+| Name | Type | [Scriptable](../options.md#scriptable-options) | Default
 | ---- | ---- | :----: | ----
 | [`adjustScaleRange`](#general) | `boolean` | Yes | `true`
-| [`backgroundColor`](#styling) | [`Color`](../options#color) | Yes | `options.color`
-| [`borderColor`](#styling) | [`Color`](../options#color) | Yes | `options.color`
+| [`backgroundColor`](#styling) | [`Color`](../options.md#color) | Yes | `options.color`
+| [`borderColor`](#styling) | [`Color`](../options.md#color) | Yes | `options.color`
 | [`borderDash`](#styling) | `number[]` | Yes | `[]`
 | [`borderDashOffset`](#styling) | `number` | Yes | `0`
-| [`borderShadowColor`](#styling) | [`Color`](../options#color) | Yes | `'transparent'`
+| [`borderShadowColor`](#styling) | [`Color`](../options.md#color) | Yes | `'transparent'`
 | [`display`](#general) | `boolean` | Yes | `true`
 | [`drawTime`](#general) | `string` | Yes | `'afterDatasetsDraw'`
 | [`id`](#general) | `string` | No | `undefined`

--- a/docs/guide/types/box.md
+++ b/docs/guide/types/box.md
@@ -6,7 +6,6 @@ Box annotations are used to draw rectangles on the chart area. This can be usefu
 /* <block:options:0> */
 const options = {
   plugins: {
-    autocolors: false,
     annotation: {
       annotations: {
         box1: {

--- a/docs/guide/types/box.md
+++ b/docs/guide/types/box.md
@@ -51,9 +51,9 @@ module.exports = {
 
 The following options are available for box annotations.
 
-| Name | Type | [Scriptable](../options#scriptable-options) | Default
+| Name | Type | [Scriptable](../options.md#scriptable-options) | Default
 | ---- | ---- | :----: | ----
-| [`backgroundShadowColor`](#styling) | [`Color`](../options#color) | Yes | `'transparent'`
+| [`backgroundShadowColor`](#styling) | [`Color`](../options.md#color) | Yes | `'transparent'`
 | [`borderCapStyle`](#styling) | `string` | Yes | `'butt'`
 | [`borderJoinStyle`](#styling) | `string` | Yes | `'miter'`
 | [`borderRadius`](#styling) | `number` \| `object` | Yes | `0`
@@ -71,7 +71,7 @@ If one of the axes does not match an axis in the chart, the box will take the en
 | ---- | ----
 | `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
 | `display` | Whether or not this annotation is visible.
-| `drawTime` | See [drawTime](../options#draw-time).
+| `drawTime` | See [drawTime](../options.md#draw-time).
 | `id` | Identifies a unique id  for the annotation and it will be stored in the element context. When the annotations are defined by an object, the id is automatically set using the key used to store the annotations in the object. When the annotations are configured by an array, the id, passed by this option in the annotation, will be used. 
 | `rotation` | Rotation of the box in degrees.
 | `xMax` | Right edge of the box in units along the x axis.
@@ -112,4 +112,4 @@ The following diagram is showing the element properties about a `'box'` annotati
 
 ![box](../../img/elementBoxProps.png)
 
-The label of a box annotation is described as a [label annotation](./label#element) and accessible by `element.label`.
+The label of a box annotation is described as a [label annotation](./label.md#element) and accessible by `element.label`.

--- a/docs/guide/types/ellipse.md
+++ b/docs/guide/types/ellipse.md
@@ -51,9 +51,9 @@ module.exports = {
 
 The following options are available for ellipse annotations.
 
-| Name | Type | [Scriptable](../options#scriptable-options) | Default
+| Name | Type | [Scriptable](../options.md#scriptable-options) | Default
 | ---- | ---- | :----: | ----
-| [`backgroundShadowColor`](#styling) | [`Color`](../options#color) | Yes | `'transparent'`
+| [`backgroundShadowColor`](#styling) | [`Color`](../options.md#color) | Yes | `'transparent'`
 | [`borderWidth`](#styling) | `number`| Yes | `1`
 | [`label`](#label) | `object` | Yes |
 | [`rotation`](#general) | `number`| Yes | `0`
@@ -68,7 +68,7 @@ If one of the axes does not match an axis in the chart, the ellipse will take th
 | ---- | ----
 | `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
 | `display` | Whether or not this annotation is visible.
-| `drawTime` | See [drawTime](../options#draw-time).
+| `drawTime` | See [drawTime](../options.md#draw-time).
 | `id` | Identifies a unique id  for the annotation and it will be stored in the element context. When the annotations are defined by an object, the id is automatically set using the key used to store the annotations in the object. When the annotations are configured by an array, the id, passed by this option in the annotation, will be used. 
 | `rotation` | Rotation of the ellipse in degrees, default is 0.
 | `xMax` | Right edge of the ellipse in units along the x axis.

--- a/docs/guide/types/ellipse.md
+++ b/docs/guide/types/ellipse.md
@@ -6,7 +6,6 @@ Ellipse annotations are used to draw circles on the chart area. This can be usef
 /* <block:options:0> */
 const options = {
   plugins: {
-    autocolors: false,
     annotation: {
       annotations: {
         ellipse1: {

--- a/docs/guide/types/label.md
+++ b/docs/guide/types/label.md
@@ -6,7 +6,6 @@ Label annotations are used to add contents on the chart area. This can be useful
 /* <block:options:0> */
 const options = {
   plugins: {
-    autocolors: false,
     annotation: {
       annotations: {
         label1: {
@@ -155,7 +154,6 @@ Namespace: `options.annotations[annotationID].callout`, it defines options for t
 /* <block:options:0> */
 const options = {
   plugins: {
-    autocolors: false,
     annotation: {
       annotations: {
         label1: {

--- a/docs/guide/types/label.md
+++ b/docs/guide/types/label.md
@@ -53,23 +53,23 @@ module.exports = {
 
 The following options are available for label annotations.
 
-| Name | Type | [Scriptable](../options#scriptable-options) | Default
+| Name | Type | [Scriptable](../options.md#scriptable-options) | Default
 | ---- | ---- | :----: | ----
-| [`backgroundShadowColor`](#styling) | [`Color`](../options#color) | Yes | `'transparent'`
+| [`backgroundShadowColor`](#styling) | [`Color`](../options.md#color) | Yes | `'transparent'`
 | [`borderCapStyle`](#styling) | `string` | Yes | `'butt'`
 | [`borderJoinStyle`](#styling) | `string` | Yes | `'miter'`
 | [`borderRadius`](#borderradius) | `number` \| `object` | Yes | `0`
 | [`borderWidth`](#styling) | `number`| Yes | `0`
 | [`callout`](#callout) | `object` | Yes |
-| [`color`](#styling) | [`Color`](../options#color) | Yes | `'black'`
+| [`color`](#styling) | [`Color`](../options.md#color) | Yes | `'black'`
 | [`content`](#general) | `string`\|`string[]`\|[`Image`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image)\|[`HTMLCanvasElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement) | Yes | `null`
-| [`font`](#styling) | [`Font`](../options#font) | Yes | `{}`
+| [`font`](#styling) | [`Font`](../options.md#font) | Yes | `{}`
 | [`height`](#general) | `number`\|`string` | Yes | `undefined`
-| [`padding`](#general) | [`Padding`](../options#padding) | Yes | `6`
+| [`padding`](#general) | [`Padding`](../options.md#padding) | Yes | `6`
 | [`position`](#position) | `string`\|`{x: string, y: string}` | Yes | `'center'`
 | [`rotation`](#general) | `number`| Yes | `0`
 | [`textAlign`](#general) | `string` | Yes | `'center'`
-| [`textStrokeColor`](#styling) | [`Color`](../options#color) | Yes | `undefined`
+| [`textStrokeColor`](#styling) | [`Color`](../options.md#color) | Yes | `undefined`
 | [`textStrokeWidth`](#styling) | `number` | Yes | `0`
 | [`width`](#general) | `number`\|`string` | Yes | `undefined`
 | [`xAdjust`](#general) | `number` | Yes | `0`
@@ -90,7 +90,7 @@ The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the bo
 | `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
 | `content` | The content to show in the text annotation.
 | `display` | Whether or not this annotation is visible.
-| `drawTime` | See [drawTime](../options#draw-time).
+| `drawTime` | See [drawTime](../options.md#draw-time).
 | `height` | Overrides the height of the image or canvas element. Could be set in pixel by a number, or in percentage of current height of image or canvas element by a string. If undefined, uses the height of the image or canvas element. It is used only when the content is an image or canvas element.
 | `id` | Identifies a unique id  for the annotation and it will be stored in the element context. When the annotations are defined by an object, the id is automatically set using the key used to store the annotations in the object. When the annotations are configured by an array, the id, passed by this option in the annotation, will be used. 
 | `padding` | The padding to add around the text label.
@@ -203,12 +203,12 @@ module.exports = {
 };
 ```
 
-All of these options can be [Scriptable](../options#scriptable-options).
+All of these options can be [Scriptable](../options.md#scriptable-options).
 
 | Name | Type | Default | Notes
 | ---- | ---- | :----: | ----
 | `borderCapStyle` | `string` | `'butt'` | Cap style of the border line of callout. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap).
-| `borderColor` | [`Color`](../options#color) | `undefined` | Stroke color of the pointer of the callout.
+| `borderColor` | [`Color`](../options.md#color) | `undefined` | Stroke color of the pointer of the callout.
 | `borderDash` | `number[]` | `[]` | Length and spacing of dashes of callout. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash).
 | `borderDashOffset` | `number` | `0` | Offset for line dashes of callout. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset).
 | `borderJoinStyle` | `string` | `'miter'` | Border line join style of the callout. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineJoin).

--- a/docs/guide/types/line.md
+++ b/docs/guide/types/line.md
@@ -6,7 +6,6 @@ Line annotations are used to draw lines on the chart area. This can be useful fo
 /* <block:options:0> */
 const options = {
   plugins: {
-    autocolors: false,
     annotation: {
       annotations: {
         line1: {

--- a/docs/guide/types/line.md
+++ b/docs/guide/types/line.md
@@ -50,7 +50,7 @@ module.exports = {
 
 The following options are available for line annotations.
 
-| Name | Type | [Scriptable](../options#scriptable-options) | Default
+| Name | Type | [Scriptable](../options.md#scriptable-options) | Default
 | ---- | ---- | :----: | ----
 | [`arrowHeads`](#arrow-heads) | `{start: object, end:object}` | Yes |
 | [`borderWidth`](#styling) | `number` | Yes | `2`
@@ -84,7 +84,7 @@ If `scaleID` is unset, then `xScaleID` and `yScaleID` are used to draw a line fr
 | ---- | ----
 | `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
 | `display` | Whether or not this annotation is visible.
-| `drawTime` | See [drawTime](../options#draw-time).
+| `drawTime` | See [drawTime](../options.md#draw-time).
 | `endValue` | End two of the line when a single scale is specified.
 | `scaleID` | ID of the scale in single scale mode. If unset, `xScaleID` and `yScaleID` are used.
 | `value` | End one of the line when a single scale is specified.
@@ -113,35 +113,35 @@ If `scaleID` is unset, then `xScaleID` and `yScaleID` are used to draw a line fr
 
 Namespace: `options.annotations[annotationID].label`, it defines options for the line annotation label.
 
-All of these options can be [Scriptable](../options#scriptable-options)
+All of these options can be [Scriptable](../options.md#scriptable-options)
 
 | Name | Type | Default | Notes
 | ---- | ---- | :----: | ----
-| `backgroundColor` | [`Color`](../options#color) | `'rgba(0,0,0,0.8)'` | Background color of the label container.
-| `backgroundShadowColor` | [`Color`](../options#color) | `'transparent'` | The color of shadow of the box where the label is located. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
+| `backgroundColor` | [`Color`](../options.md#color) | `'rgba(0,0,0,0.8)'` | Background color of the label container.
+| `backgroundShadowColor` | [`Color`](../options.md#color) | `'transparent'` | The color of shadow of the box where the label is located. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
 | `borderCapStyle` | `string` | `'butt'` | Cap style of the border line. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap).
-| `borderColor` | [`Color`](../options#color) | `black` | The border line color.
+| `borderColor` | [`Color`](../options.md#color) | `black` | The border line color.
 | `borderDash` | `number[]` | `[]` | Length and spacing of dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash).
 | `borderDashOffset` | `number` | `0` | Offset for border line dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset).
 | `borderJoinStyle` | `string` | `'miter'` | Border line join style. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineJoin).
 | [`borderRadius`](#borderradius) | `number` \| `object` | `6` | Radius of label box corners in pixels.
-| `borderShadowColor` | [`Color`](../options#color) | `'transparent'` | The color of border shadow of the box where the label is located. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
+| `borderShadowColor` | [`Color`](../options.md#color) | `'transparent'` | The color of border shadow of the box where the label is located. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
 | `borderWidth` | `number` | `0` | The border line width (in pixels).
 | [`callout`](#callout) | `object` | | Can connect the label to the line. See [callout](#callout).
-| `color` | [`Color`](../options#color) | `'#fff'` | Text color.
+| `color` | [`Color`](../options.md#color) | `'#fff'` | Text color.
 | `content` | `string`\|`string[]`\|[`Image`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image)\|[`HTMLCanvasElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement) | `null` | The content to show in the label.
 | `display` | `boolean` | `false` | Whether or not the label is shown.
-| `drawTime` | `string` | `options.drawTime` | See [drawTime](../options#draw-time). Defaults to the line annotation draw time if unset.
-| `font` | [`Font`](../options#font) | `{ weight: 'bold' }` | Label font.
+| `drawTime` | `string` | `options.drawTime` | See [drawTime](../options.md#draw-time). Defaults to the line annotation draw time if unset.
+| `font` | [`Font`](../options.md#font) | `{ weight: 'bold' }` | Label font.
 | `height` | `number`\|`string` | `undefined` | Overrides the height of the image or canvas element. Could be set in pixel by a number, or in percentage of current height of image or canvas element by a string. If undefined, uses the height of the image or canvas element. It is used only when the content is an image or canvas element.
-| `padding` | [`Padding`](../options#padding) | `6` | The padding to add around the text label.
+| `padding` | [`Padding`](../options.md#padding) | `6` | The padding to add around the text label.
 | `position` | `string` | `'center'` | Anchor position of label on line. Possible options are: `'start'`, `'center'`, `'end'`. It can be set by a string in percentage format `'number%'` which are representing the percentage on the width of the line where the label will be located.
 | `rotation` | `number`\|`'auto'` | `0` | Rotation of label, in degrees, or 'auto' to use the degrees of the line.
 | `shadowBlur` | `number` | `0` | The amount of blur applied to shadow of the box where the label is located. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowBlur).
 | `shadowOffsetX` | `number` | `0` | The distance that shadow, of the box where the label is located, will be offset horizontally. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowOffsetX).
 | `shadowOffsetY` | `number` | `0` | The distance that shadow, of the box where the label is located, will be offset vertically. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowOffsetY).
 | `textAlign` | `string` | `'center'` | Text alignment of label content when there's more than one line. Possible options are: `'start'`, `'center'`, `'end'`.
-| `textStrokeColor` | [`Color`](../options#color) | `undefined` | The color of the stroke around the text.
+| `textStrokeColor` | [`Color`](../options.md#color) | `undefined` | The color of the stroke around the text.
 | `textStrokeWidth` | `number` | `0` | Stroke width around the text.
 | `width` | `number`\|`string` | `undefined` | Overrides the width of the image or canvas element. Could be set in pixel by a number, or in percentage of current width of image or canvas element by a string. If undefined, uses the width of the image or canvas element. It is used only when the content is an image or canvas element.
 | `xAdjust` | `number` | `0` | Adjustment along x-axis (left-right) of label relative to computed position. Negative values move the label left, positive right.
@@ -158,12 +158,12 @@ A callout can connect the label to the line when the label is arbitrarily (by `x
 
 Namespace: `options.annotations[annotationID].label.callout`, it defines options for the callout on the label of the line annotation.
 
-All of these options can be [Scriptable](../options#scriptable-options).
+All of these options can be [Scriptable](../options.md#scriptable-options).
 
 | Name | Type | Default | Notes
 | ---- | ---- | :----: | ----
 | `borderCapStyle` | `string` | `'butt'` | Cap style of the border line of callout. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap).
-| `borderColor` | [`Color`](../options#color) | `undefined` | Stroke color of the pointer of the callout.
+| `borderColor` | [`Color`](../options.md#color) | `undefined` | Stroke color of the pointer of the callout.
 | `borderDash` | `number[]` | `[]` | Length and spacing of dashes of callout. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash).
 | `borderDashOffset` | `number` | `0` | Offset for line dashes of callout. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset).
 | `borderJoinStyle` | `string` | `'miter'` | Border line join style of the callout. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineJoin).
@@ -178,7 +178,7 @@ All of these options can be [Scriptable](../options#scriptable-options).
 
 Namespace: `options.annotations[annotationID].arrowHeads`, it defines options for the line annotation arrow heads.
 
-All of these options can be [Scriptable](../options#scriptable-options)
+All of these options can be [Scriptable](../options.md#scriptable-options)
 
 | Name | Type | Notes
 | ---- | ---- | ----
@@ -191,16 +191,16 @@ Enabling it, you can add arrow heads at start and/or end of a line. It uses the 
 
 The following options can be specified per (`start` and/or `end`) arrow head, or at the top level (`arrowHeads`) which apply to all arrow heads.
 
-All of these options can be [Scriptable](../options#scriptable-options)
+All of these options can be [Scriptable](../options.md#scriptable-options)
 
 | Name | Type | Default | Notes
 | ---- | ---- | :----: | ---- 
-| `backgroundColor` | [`Color`](../options#color) | `lineAnnotation.borderColor` | Background color of the arrow head.
-| `backgroundShadowColor` | [`Color`](../options#color) | `'transparent'` | The color of shadow of the arrow head. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
-| `borderColor` | [`Color`](../options#color) | `lineAnnotation.borderColor` | The border arrow head color.
+| `backgroundColor` | [`Color`](../options.md#color) | `lineAnnotation.borderColor` | Background color of the arrow head.
+| `backgroundShadowColor` | [`Color`](../options.md#color) | `'transparent'` | The color of shadow of the arrow head. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
+| `borderColor` | [`Color`](../options.md#color) | `lineAnnotation.borderColor` | The border arrow head color.
 | `borderDash` | `number[]` | `lineAnnotation.borderDash` | Length and spacing of dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash).
 | `borderDashOffset` | `number` | `lineAnnotation.borderDashOffset` | Offset for border arrow head dashes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset).
-| `borderShadowColor` | [`Color`](../options#color) | `lineAnnotation.borderShadowColor` | The color of border shadow of the arrow head. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
+| `borderShadowColor` | [`Color`](../options.md#color) | `lineAnnotation.borderShadowColor` | The color of border shadow of the arrow head. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/shadowColor).
 | `borderWidth` | `number` | `lineAnnotation.borderWidth` | The border line width (in pixels).
 | `display` | `boolean` | `false` | Whether or not the arrow head is shown.
 | `fill` | `boolean` | `false` | Whether or not the arrow head is filled.
@@ -216,4 +216,4 @@ The following diagram is showing the element properties about a `'line'` annotat
 
 ![line](../../img/elementLineProps.png)
 
-The label of a box annotation is described as a [label annotation](./label#element) and accessible by `element.label`.
+The label of a box annotation is described as a [label annotation](./label.md#element) and accessible by `element.label`.

--- a/docs/guide/types/point.md
+++ b/docs/guide/types/point.md
@@ -6,7 +6,6 @@ Point annotations are used to mark points on the chart area. This can be useful 
 /* <block:options:0> */
 const options = {
   plugins: {
-    autocolors: false,
     annotation: {
       annotations: {
         point1: {

--- a/docs/guide/types/point.md
+++ b/docs/guide/types/point.md
@@ -49,11 +49,11 @@ module.exports = {
 
 The following options are available for point annotations.
 
-| Name | Type | [Scriptable](../options#scriptable-options) | Default
+| Name | Type | [Scriptable](../options.md#scriptable-options) | Default
 | ---- | ---- | :----: | ----
-| [`backgroundShadowColor`](#styling) | [`Color`](../options#color) | Yes | `'transparent'`
+| [`backgroundShadowColor`](#styling) | [`Color`](../options.md#color) | Yes | `'transparent'`
 | [`borderWidth`](#styling) | `number`| Yes | `1`
-| [`pointStyle`](#styling) | [`PointStyle`](../options#point-style) | Yes | `'circle'`
+| [`pointStyle`](#styling) | [`PointStyle`](../options.md#point-style) | Yes | `'circle'`
 | [`radius`](#general) | `number` | Yes | `10`
 | [`rotation`](#general) | `number` | Yes | `0`
 | [`xAdjust`](#general) | `number` | Yes | `0`
@@ -73,7 +73,7 @@ The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the bo
 | ---- | ----
 | `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
 | `display` | Whether or not this annotation is visible.
-| `drawTime` | See [drawTime](../options#draw-time).
+| `drawTime` | See [drawTime](../options.md#draw-time).
 | `id` | Identifies a unique id  for the annotation and it will be stored in the element context. When the annotations are defined by an object, the id is automatically set using the key used to store the annotations in the object. When the annotations are configured by an array, the id, passed by this option in the annotation, will be used. 
 | `radius` | Size of the point in pixels.
 | `rotation` | Rotation of point, in degrees.

--- a/docs/guide/types/polygon.md
+++ b/docs/guide/types/polygon.md
@@ -51,9 +51,9 @@ module.exports = {
 
 The following options are available for polygon annotations.
 
-| Name | Type | [Scriptable](../options#scriptable-options) | Default
+| Name | Type | [Scriptable](../options.md#scriptable-options) | Default
 | ---- | ---- | :----: | ----
-| [`backgroundShadowColor`](#styling) | [`Color`](../options#color) | Yes | `'transparent'`
+| [`backgroundShadowColor`](#styling) | [`Color`](../options.md#color) | Yes | `'transparent'`
 | [`borderCapStyle`](#styling) | `string` | Yes | `'butt'`
 | [`borderJoinStyle`](#styling) | `string` | Yes | `'miter'`
 | [`borderWidth`](#styling) | `number`| Yes | `1`
@@ -78,7 +78,7 @@ The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the bo
 | ---- | ----
 | `adjustScaleRange` | Should the scale range be adjusted if this annotation is out of range.
 | `display` | Whether or not this annotation is visible.
-| `drawTime` | See [drawTime](../options#draw-time).
+| `drawTime` | See [drawTime](../options.md#draw-time).
 | `id` | Identifies a unique id  for the annotation and it will be stored in the element context. When the annotations are defined by an object, the id is automatically set using the key used to store the annotations in the object. When the annotations are configured by an array, the id, passed by this option in the annotation, will be used. 
 | `radius` | Size of the polygon in pixels.
 | `rotation` | Rotation of polygon, in degrees.
@@ -114,7 +114,7 @@ The 4 coordinates, xMin, xMax, yMin, yMax are optional. If not specified, the bo
 
 ### Point
 
-Polygon consists of points. These points are actually [Point Annotations](point) and all of the [styling options](point#styling) can be configured. General options affecting the location of the point are ignored.
+Polygon consists of points. These points are actually [Point Annotations](point) and all of the [styling options](point.md#styling) can be configured. General options affecting the location of the point are ignored.
 
 Namespace: `options.annotations[annotationID].point`, it defines options for the callout on the annotation label.
 

--- a/docs/guide/types/polygon.md
+++ b/docs/guide/types/polygon.md
@@ -6,7 +6,6 @@ Polygon annotations are used to mark whatever polygon (for instance triangle, sq
 /* <block:options:0> */
 const options = {
   plugins: {
-    autocolors: false,
     annotation: {
       annotations: {
         pentagon: {
@@ -122,7 +121,6 @@ Namespace: `options.annotations[annotationID].point`, it defines options for the
 /* <block:options:0> */
 const options = {
   plugins: {
-    autocolors: false,
     annotation: {
       annotations: {
         pentagon: {

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -18,7 +18,6 @@ const config = {
   },
   options: {
     plugins: {
-      autocolors: false,
       annotation: {
         annotations: {
           box1: {

--- a/docs/scripts/utils.js
+++ b/docs/scripts/utils.js
@@ -119,7 +119,6 @@ function createChart(canvas) {
       responsive: false,
       animation: false,
       plugins: {
-        autocolors: false,
         version: false,
         legend: false,
         title: false,


### PR DESCRIPTION
Fix #818 

This PR is also removing the `autocolors` configuration plugin from the guide.