### PR TITLE
Use isFunction helper of Chart.js instead of internal check

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1,4 +1,4 @@
-import {callback} from 'chart.js/helpers';
+import {isFunction, callback} from 'chart.js/helpers';
 import {getElements} from './interaction';
 import {loadHooks} from './helpers';
 
@@ -22,19 +22,19 @@ export function updateListeners(chart, state, options) {
   state._getElements = getElements; // for testing
 
   moveHooks.forEach(hook => {
-    if (typeof options[hook] === 'function') {
+    if (isFunction(options[hook])) {
       state.moveListened = true;
     }
   });
 
   if (!state.listened || !state.moveListened) {
     state.annotations.forEach(scope => {
-      if (!state.listened && typeof scope.click === 'function') {
+      if (!state.listened && isFunction(scope.click)) {
         state.listened = true;
       }
       if (!state.moveListened) {
         moveHooks.forEach(hook => {
-          if (typeof scope[hook] === 'function') {
+          if (isFunction(scope[hook])) {
             state.listened = true;
             state.moveListened = true;
           }

--- a/src/helpers/helpers.options.js
+++ b/src/helpers/helpers.options.js
@@ -1,4 +1,4 @@
-import {isObject, valueOrDefault, defined} from 'chart.js/helpers';
+import {isObject, isFunction, valueOrDefault, defined} from 'chart.js/helpers';
 import {clamp} from './helpers.core';
 
 const isPercentString = (s) => typeof s === 'string' && s.endsWith('%');
@@ -96,7 +96,7 @@ export function isBoundToPoint(options) {
 export function loadHooks(options, hooks, hooksContainer) {
   let activated = false;
   hooks.forEach(hook => {
-    if (typeof options[hook] === 'function') {
+    if (isFunction(options[hook])) {
       activated = true;
       hooksContainer[hook] = options[hook];
     } else if (defined(hooksContainer[hook])) {

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,4 +1,4 @@
-import {callback} from 'chart.js/helpers';
+import {isFunction, callback} from 'chart.js/helpers';
 import {loadHooks} from './helpers';
 
 /**
@@ -22,7 +22,7 @@ export function updateHooks(chart, state, options) {
     visibleElements.forEach(scope => {
       if (!state.hooked) {
         elementHooks.forEach(hook => {
-          if (typeof scope.options[hook] === 'function') {
+          if (isFunction(scope.options[hook])) {
             state.hooked = true;
           }
         });

--- a/src/scale.js
+++ b/src/scale.js
@@ -1,4 +1,4 @@
-import {isFinite, valueOrDefault, defined} from 'chart.js/helpers';
+import {isFinite, isFunction, valueOrDefault, defined} from 'chart.js/helpers';
 import {retrieveScaleID} from './helpers';
 
 /**
@@ -16,7 +16,7 @@ export function adjustScaleRange(chart, scale, annotations) {
   const range = getScaleLimits(chart.scales, scale, annotations);
   let changed = changeScaleLimit(scale, range, 'min', 'suggestedMin');
   changed = changeScaleLimit(scale, range, 'max', 'suggestedMax') || changed;
-  if (changed && typeof scale.handleTickRangeOptions === 'function') {
+  if (changed && isFunction(scale.handleTickRangeOptions)) {
     scale.handleTickRangeOptions();
   }
 }


### PR DESCRIPTION
This PR is removing internal checks if an instance is a function using the Chart.js herlper