### PR TITLE
Disable canvas acceleration in Firefox 110 in test cases

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -42,6 +42,8 @@ module.exports = function(karma) {
     // Explicitly disable hardware acceleration to make image
     // diff more stable when ran on Travis and dev machine.
     // https://github.com/chartjs/Chart.js/pull/5629
+    // Since FF 110, in FF GPU-accelerated Canvas2D is enabled by default on macOS and Linux.
+    // This is braking fixture test cases, therefore is disabled by setting gfx.canvas.accelerated
     customLaunchers: {
       chrome: {
         base: 'Chrome',
@@ -55,7 +57,8 @@ module.exports = function(karma) {
       firefox: {
         base: 'Firefox',
         prefs: {
-          'layers.acceleration.disabled': true
+          'layers.acceleration.disabled': true,
+          'gfx.canvas.accelerated': false
         }
       }
     },


### PR DESCRIPTION
See https://github.com/chartjs/chartjs-plugin-annotation/pull/856.

Firefox 110 added the following feature: **GPU-accelerated Canvas2D is enabled by default on macOS and Linux**.
It seems that this is breaking the test cases on fixtures.
This PR is trying to disable it.