### PR TITLE
Fix value stored in element options for indexable option

### DIFF
--- a/src/elements.js
+++ b/src/elements.js
@@ -1,5 +1,5 @@
 import {Animations} from 'chart.js';
-import {isObject, defined} from 'chart.js/helpers';
+import {isObject, isArray, defined} from 'chart.js/helpers';
 import {eventHooks} from './events';
 import {elementHooks} from './hooks';
 import {annotationTypes} from './types';
@@ -131,7 +131,11 @@ function resolveObj(resolver, defs) {
   for (const prop of Object.keys(defs)) {
     const optDefs = defs[prop];
     const value = resolver[prop];
-    result[prop] = isObject(optDefs) && !isIndexable(prop) ? resolveObj(value, optDefs) : value;
+    if (isIndexable(prop) && isArray(value)) {
+      result[prop] = value.map((item) => isObject(optDefs) ? resolveObj(item, optDefs) : item);
+    } else {
+      result[prop] = isObject(optDefs) ? resolveObj(value, optDefs) : value;
+    }
   }
   return result;
 }

--- a/src/elements.js
+++ b/src/elements.js
@@ -9,6 +9,8 @@ const directUpdater = {
 };
 
 const hooks = eventHooks.concat(elementHooks);
+const resolve = (value, optDefs) => isObject(optDefs) ? resolveObj(value, optDefs) : value;
+
 
 /**
  * @typedef { import("chart.js").Chart } Chart
@@ -132,9 +134,9 @@ function resolveObj(resolver, defs) {
     const optDefs = defs[prop];
     const value = resolver[prop];
     if (isIndexable(prop) && isArray(value)) {
-      result[prop] = value.map((item) => isObject(optDefs) ? resolveObj(item, optDefs) : item);
+      result[prop] = value.map((item) => resolve(item, optDefs));
     } else {
-      result[prop] = isObject(optDefs) ? resolveObj(value, optDefs) : value;
+      result[prop] = resolve(value, optDefs);
     }
   }
   return result;


### PR DESCRIPTION
The PR https://github.com/chartjs/chartjs-plugin-annotation/pull/801 introduced indexable options (`font` and `color`).

The current options resolution is checking if the options is indexable and if true, it stores the value of the options.

https://github.com/chartjs/chartjs-plugin-annotation/blob/bc38d6bfad27a052c199604e89d1338c07681d3f/src/elements.js#L134

In this way, it stores a `Proxy` object (or an array of `Proxy`) in element options, something that probably you don't want.

This PR is storing "plain" objects as `element.options`. 