### PR TITLE
Update migration guide for version 3

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -42,7 +42,7 @@ template: |
   # Essential Links
 
   * [npm](https://www.npmjs.com/package/chartjs-plugin-annotation)
-  * [Migration guide](https://www.chartjs.org/chartjs-plugin-annotation/latest/guide/migrationV2.html)
+  * [Migration guide](https://www.chartjs.org/chartjs-plugin-annotation/latest/guide/migrationV3.html)
   * [Docs](https://www.chartjs.org/chartjs-plugin-annotation/)
   * [API](https://www.chartjs.org/chartjs-plugin-annotation/latest/api/)
   * [Samples](https://www.chartjs.org/chartjs-plugin-annotation/latest/samples/intro.html)

--- a/docs/guide/migrationV3.md
+++ b/docs/guide/migrationV3.md
@@ -6,3 +6,7 @@ The [UMD bundle](integration.md#script-tag) is still available.
 ## Chart.js version
 
 The annotation plugin requires at least version 4.0.0 to work because of Chart.js becomes an ESM-only package.
+
+### Type changes
+
+* The `init` options callback return value types have been changed from `void | boolean | AnnotationBoxModel` to `void | boolean | AnnotationElement`.


### PR DESCRIPTION
This PR is updating the migration guide for version 3 and the link in the release drafter template.