### PR TITLE
Fix documentation after setting plugin as module

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -101,8 +101,8 @@ export default defineConfig({
     docsDir: 'docs',
     chart: {
       imports: [
-        ['scripts/register.js'],
-        ['scripts/defaults.js'],
+        ['scripts/register.js', 'Register'],
+        ['scripts/defaults.js', 'Defaults'],
         ['scripts/utils.js', 'Utils'],
       ]
     },


### PR DESCRIPTION
This Pr should fix the issue related to the documentation where the chart instances are not available because the chart.js elements are not registered.

The issue sounds to be related to `vuepress-theme-chartjs` and how imports are managed. 
Not clear to me why (apologize) but adding the import names where missing, the app built by webpack/vue seems to have the registration and is importing everything as it should. 