### PR TITLE
Remove default type from module augmentation of PluginOptionsByType

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@ import { AnnotationPluginOptions, BoxAnnotationOptions, EllipseAnnotationOptions
 
 declare module 'chart.js' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface PluginOptionsByType<TType extends ChartType = ChartType> {
+  interface PluginOptionsByType<TType extends ChartType> {
     annotation: AnnotationPluginOptions;
   }
 


### PR DESCRIPTION
Fix #886 revert #877 because the the root cause of the bug was different and fixed in CHART.JS by https://github.com/chartjs/Chart.js/pull/11309

Waiting for new CHART.JS version here the mentioned above PR will be published.