### PR TITLE
Replace chart.min.js by chart.umd.js

### DIFF
--- a/docs/guide/integration.md
+++ b/docs/guide/integration.md
@@ -7,7 +7,7 @@ title: Integration
 ## Script Tag
 
 ```html
-<script src="path/to/chartjs/dist/chart.min.js"></script>
+<script src="path/to/chartjs/dist/chart.umd.js"></script>
 <script src="path/to/chartjs-plugin-annotation/dist/chartjs-plugin-annotation.min.js"></script>
 <script>
     var myChart = new Chart(ctx, {...});


### PR DESCRIPTION
There is no `chart.min.js` file when you `npm install chart.js`. I supposed it has been replaced by `chart.umd.js` as indicated in the [Chart.js integration documentation](https://www.chartjs.org/docs/latest/getting-started/integration.html). 