### PR TITLE
Fix spacing applied to doughnut label

### DIFF
--- a/src/types/doughnutLabel.js
+++ b/src/types/doughnutLabel.js
@@ -136,7 +136,7 @@ function getControllerMeta({chartArea}, options, meta) {
     y: (square.top + square.bottom) / 2
   };
   const space = options.spacing + options.borderWidth / 2;
-  const _radius = innerRadius - space;
+  const _radius = Math.max(innerRadius - space, 0);
   const _counterclockwise = point.y > y;
   const side = _counterclockwise ? top + space : bottom - space;
   const angles = getAngles(side, x, y, _radius);
@@ -150,7 +150,7 @@ function getControllerMeta({chartArea}, options, meta) {
   return {
     controllerMeta,
     point,
-    radius: Math.min(innerRadius, Math.min(square.right - square.left, square.bottom - square.top) / 2)
+    radius: Math.min(_radius, Math.min(square.right - square.left, square.bottom - square.top) / 2)
   };
 }
 


### PR DESCRIPTION
Fix https://github.com/chartjs/chartjs-plugin-annotation/issues/952

This PR is fixing label calculation where `spacing` option is configured.