### PR TITLE
Update type definitions for elements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Please do not use issues for support requests. For help using the annotation plu
 
 Well structured, detailed bug reports are hugely valuable for the project.
 
-Guidlines for reporting bugs:
+Guidelines for reporting bugs:
 
 - Check the issue search to see if it has already been reported
 - Isolate the problem to a simple test case

--- a/types/element.d.ts
+++ b/types/element.d.ts
@@ -10,9 +10,16 @@ export interface AnnotationBoxModel {
   height: number,
   width: number,
   radius?: number
+  // Used by polygon annotations' child point AnnotationElements
+  bx?: number;
+  by?: number;
 }
 
 export interface AnnotationElement extends AnnotationBoxModel {
   label?: AnnotationElement,
-  options: AnnotationOptions
+  options: AnnotationOptions,
+  /**
+   * Sub-elements: e.g., a box annotation's label, or a polygon's points
+   */
+  elements?: AnnotationElement[],
 }


### PR DESCRIPTION
This adds type definitions for the properties accessed by the draggable demo:

https://www.chartjs.org/chartjs-plugin-annotation/latest/samples/interaction/dragging.html