### PR TITLE
Fix types for scriptable `init`

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -35,6 +35,14 @@ interface ShadowOptions {
   shadowOffsetY?: Scriptable<number, PartialEventContext>
 }
 
+export interface InitContext {
+  chart: Chart,
+  properties: AnnotationBoxModel,
+  options: AnnotationOptions
+}
+
+export type ScriptableInit = boolean | ((ctx: InitContext) => void | boolean | Partial<AnnotationElement>);
+
 export interface CoreAnnotationOptions extends AnnotationEvents, ShadowOptions, AnnotationHooks {
   adjustScaleRange?: Scriptable<boolean, PartialEventContext>,
   borderColor?: Scriptable<Color, PartialEventContext>,
@@ -44,7 +52,7 @@ export interface CoreAnnotationOptions extends AnnotationEvents, ShadowOptions, 
   display?: Scriptable<boolean, PartialEventContext>,
   drawTime?: Scriptable<DrawTime, PartialEventContext>,
   hitTolerance?: Scriptable<number, PartialEventContext>,
-  init?: boolean | (({ chart: Chart, properties: AnnotationBoxModel, options: AnnotationOptions }) => void | boolean | Partial<AnnotationElement>),
+  init?: ScriptableInit,
   id?: string,
   xMax?: Scriptable<ScaleValue, PartialEventContext>,
   xMin?: Scriptable<ScaleValue, PartialEventContext>,
@@ -138,17 +146,11 @@ export interface LabelAnnotationOptions extends CoreAnnotationOptions, LabelType
   rotation?: Scriptable<number, PartialEventContext>
 }
 
-interface InitContext {
-  chart: Chart,
-  properties: AnnotationBoxModel,
-  options: AnnotationOptions
-}
-
 export interface DoughnutLabelAnnotationOptions extends AnnotationEvents, DoughnutLabelOptions, ShadowOptions {
   autoFit?: Scriptable<boolean, PartialEventContext>,
   autoHide?: Scriptable<boolean, PartialEventContext>,
   id?: string,
-  init: boolean | ((ctx: InitContext) => void | boolean | AnnotationElement),
+  init?: ScriptableInit,
   spacing?: Scriptable<number, PartialEventContext>
 }
 

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -138,11 +138,17 @@ export interface LabelAnnotationOptions extends CoreAnnotationOptions, LabelType
   rotation?: Scriptable<number, PartialEventContext>
 }
 
+interface InitContext {
+  chart: Chart,
+  properties: AnnotationBoxModel,
+  options: AnnotationOptions
+}
+
 export interface DoughnutLabelAnnotationOptions extends AnnotationEvents, DoughnutLabelOptions, ShadowOptions {
   autoFit?: Scriptable<boolean, PartialEventContext>,
   autoHide?: Scriptable<boolean, PartialEventContext>,
   id?: string,
-  init: boolean | ((chart: Chart, properties: AnnotationBoxModel, options: AnnotationOptions) => void | boolean | AnnotationBoxModel),
+  init: boolean | ((ctx: InitContext) => void | boolean | AnnotationElement),
   spacing?: Scriptable<number, PartialEventContext>
 }
 


### PR DESCRIPTION
It takes its parameters as a context object, not three separate parameters. configuration.md and migrationV3.md explain that it returns an AnnotationBoxModel, not an AnnotationElement.